### PR TITLE
Contact info tidying

### DIFF
--- a/app/controllers/contact_information_controller.rb
+++ b/app/controllers/contact_information_controller.rb
@@ -1,6 +1,6 @@
 class ContactInformationController < ApplicationController
   def show
-    @contact_information = ContactInformation.get_by_id(params[:id])
+    @contact_information = ContactInformation.get_by_id(params[:id]) 
     respond_to do |format|
       format.html # index.html.erb
       format.json { render :json => @contact_information }
@@ -10,7 +10,7 @@ class ContactInformationController < ApplicationController
   # GET /contact_information/Administrator/edit
   def edit
     administrators_only
-    @contact_information = ContactInformation.get_by_id(params[:id])
+    @contact_information = ContactInformation.get_or_create(params[:id])
   end
   
   # POST /contact_information/Administrator

--- a/app/models/contact_information.rb
+++ b/app/models/contact_information.rb
@@ -12,6 +12,11 @@ class ContactInformation < CouchRestRails::Document
   
   def self.get_by_id id
     result = self.all.select{|x|x.id==id}.first
+    raise ErrorResponse.not_found("Cannot find ContactInformation with id #{id}") if result.nil?
+    return result
+  end
+  def self.get_or_create id
+    result = self.all.select{|x|x.id==id}.first
     return result if !result.nil?
     new_contact_info = ContactInformation.new :id=>id
     new_contact_info.save!

--- a/app/views/shared/status_404.html.erb
+++ b/app/views/shared/status_404.html.erb
@@ -1,0 +1,2 @@
+<h1><%=@exception.status_text%></h1>
+<h2><%=@exception.message%></h2>

--- a/features/editing_contact_info.feature
+++ b/features/editing_contact_info.feature
@@ -24,6 +24,7 @@ Feature: Allowing admin contact info to be specified
 	Then I should see "Contact information was successfully updated."
 	And the "Name" field should contain "Barney Rubble"
 	And the "Organization" field should contain "Slate Rock and Gravel Company"
+	
   Scenario: Only admins can edit contact info
  	When I am logged in
 	Then I should not be able to see the edit administrator contact information page
@@ -46,26 +47,4 @@ Feature: Allowing admin contact info to be specified
 	And I should see "Foo@bar.com" within "#contact_info_email"
 	And I should see "Uganda" within "#contact_info_location"
 	And I should see "Please let us know if your password goes missing!" within "#contact_info_other_information"
-  
-  # Background:
-  #   Given I am logged in
-  # 
-  # Scenario: From saved record page clicking on 'Home' link redirects to initial start page
-  #   Given the following children exist in the system:
-  #     | name  |
-  #     | Lisa	|
-  #   And I am on the child search page
-  # 
-  #   When I search using a name of "Lisa"
-  #   Then I should be on the saved record page for child with name "Lisa"
-  # 
-  #   When I follow "Home"
-  #   Then I should be on the home page
-  # 
-  # Scenario: The homepage should contain useful links and welcome text
-  # 
-  #   Given I am on the home page
-  # 
-  #   Then I should see "Welcome to RapidFTR"
-  #   Then I should see "Add child record"
-  #   Then I should see "View child listing"
+

--- a/lib/error_response.rb
+++ b/lib/error_response.rb
@@ -9,6 +9,10 @@ class ErrorResponse < StandardError
   def self.unauthorized(message)
     new( 401, message )
   end
+  
+  def self.not_found(message)
+    new( 404, message )
+  end
 
   def initialize( status_code, message )
     @status_code = status_code

--- a/spec/controllers/contact_information_controller_spec.rb
+++ b/spec/controllers/contact_information_controller_spec.rb
@@ -7,8 +7,8 @@ describe ContactInformationController do
   describe "GET edit" do
     it "populates the contact information" do
       contact_information = {"name"=>"Bob"}
-      ContactInformation.stub!(:get_by_id).with("administrator").and_return(contact_information)
-      get :edit, :id => "administrator"
+      ContactInformation.stub!(:get_or_create).with("bob").and_return(contact_information)
+      get :edit, :id => "bob"
       assigns[:contact_information].should == contact_information
     end
   end
@@ -20,6 +20,11 @@ describe ContactInformationController do
       get :show, :id => "administrator"
       response_as_json =  JSON.parse @response.body
       response_as_json.should == {"name"=>"Bob"}
+    end
+    it "should 404 if showing a contact information that does not exist" do
+      ContactInformation.stub!(:get_by_id).with("foo").and_raise(ErrorResponse.not_found("Contact information not found"))
+      get :show, :id => "foo"
+      response.status.should =~ /404/
     end
   end
   

--- a/spec/models/contact_information_spec.rb
+++ b/spec/models/contact_information_spec.rb
@@ -1,10 +1,27 @@
 require 'spec_helper'
 describe ContactInformation do
-  describe "get_by_id" do
+  before :each do
+    ContactInformation.all.each {|contact_info| contact_info.destroy}
+  end
+  describe "get_or_create" do
     it "Should create the contact information if it does not exist" do
-      contact_info = ContactInformation.get_by_id "ThisIsATest"
+      contact_info = ContactInformation.get_or_create "ThisIsATest"
       contact_info.should_not be_nil
+      contact_info.id.should == "ThisIsATest"
       ContactInformation.all[0].id.should == "ThisIsATest"
+    end
+  end
+  describe "get_by_id" do
+    it "Should return a contact info by id" do
+      expected = ContactInformation.new({:id=>"ThisIsATest"})
+      expected.save!
+      contact_info = ContactInformation.get_by_id "ThisIsATest"
+      contact_info.should == expected
+    end
+    it "should raise if contact info doesn't exist" do
+      lambda { 
+               ContactInformation.get_by_id "ThisIsATest"
+            }.should raise_error( ErrorResponse )
     end
   end
 end


### PR DESCRIPTION
Some small changes to contact info. now get-on-create only happens when you edit not when a contact info is shown. If you try and view a non existent contact info like contact_info/Foo it doesn't create it for you (though contact_info/Foo/edit would still).
