### PR TITLE
582 require unique form section name

### DIFF
--- a/app/models/form_section.rb
+++ b/app/models/form_section.rb
@@ -14,6 +14,7 @@ class FormSection < CouchRestRails::Document
 
   validates_presence_of :name
   validates_format_of :name, :with =>/^([a-zA-Z0-9_\s]*)$/, :message=>"Name must contain only alphanumeric characters and spaces"
+  validates_with_method :name, :method => :validate_unique_name
 
   def initialize args={}
     self["fields"] = []
@@ -122,4 +123,10 @@ class FormSection < CouchRestRails::Document
     matching_fields.each{ |field| field.enabled = true}
   end
 
+  protected
+
+  def validate_unique_name
+    unique = FormSection.all.all? {|f| id == f.id || name != f.name }
+    unique || [false, "The name '#{name}' is already taken."]
+  end
 end

--- a/spec/models/form_section_spec.rb
+++ b/spec/models/form_section_spec.rb
@@ -258,10 +258,25 @@ describe FormSection do
     it "should validate name is filled in" do
       form_section = FormSection.new()
       form_section.should_not be_valid
+      form_section.errors.on(:name).should be_present
     end
     it "should validate name is alpha_num" do
       form_section = FormSection.new(:name=>"££ss")
       form_section.should_not be_valid
+      form_section.errors.on(:name).should be_present
+    end
+    it "should validate name is unique" do
+      same_name = 'Same Name'
+      valid_attributes = {:name => same_name, :unique_id => same_name.dehumanize, :description => '', :enabled => true}
+      FormSection.create! valid_attributes.dup
+      form_section = FormSection.new valid_attributes.dup
+      form_section.should_not be_valid
+      form_section.errors.on(:name).should be_present
+    end
+    it "should not trip the unique name validation on self" do
+      form_section = FormSection.new(:name => 'Unique Name', :unique_id => 'unique_name')
+      form_section.create!
+      form_section.should be_valid
     end
   end
 


### PR DESCRIPTION
Added a validation. Had to do it custom since there's no validates_uniqueness_of built into CouchRest. Should be acceptable to do it inefficiently since the number of form sections should always be small. We'll eventually need to do something to guarantee unique keys are truly unique, but this will prevent the case described in the story (which would be confusing for users even if we were generating unique keys independent of form section names).
