### PR TITLE
#555 Custom date field issue in the blackberry client

### DIFF
--- a/app/models/child.rb
+++ b/app/models/child.rb
@@ -30,6 +30,7 @@ class Child < CouchRestRails::Document
   validates_fields_of_type Field::NUMERIC_FIELD
   validates_fields_of_type Field::TEXT_FIELD
   validates_fields_of_type Field::TEXT_AREA
+  validates_fields_of_type Field::DATE_FIELD
   validates_with_method :age, :method => :validate_age
     
   def validate_age

--- a/app/views/children/_date_field.html.erb
+++ b/app/views/children/_date_field.html.erb
@@ -1,5 +1,5 @@
 <p>
   <%= label_tag date_field.tag_name_attribute, date_field.display_name %>
   <%= text_field_tag date_field.tag_name_attribute, @child[date_field.name] %>
-  <%= javascript_tag "$(document).ready(function(){ $(\"##{date_field.tag_id}\").datepicker({ dateFormat: 'dd/mm/yy' }); });" %>
+  <%= javascript_tag "$(document).ready(function(){ $(\"##{date_field.tag_id}\").datepicker({ dateFormat: 'dd M yy' }); });" %>
 </p>

--- a/features/add_custom_field_to_form_section.feature
+++ b/features/add_custom_field_to_form_section.feature
@@ -64,9 +64,9 @@ Feature: So that admin can customize fields in a form section
     And I follow "New child"
 
     Then I should see "Anything"
-    When I fill in "11/17/2010" for "child_anything"
+    When I fill in "17 Nov 2010" for "child_anything"
     And I press "Save"
-    Then I should see "11/17/2010"
+    Then I should see "17 Nov 2010"
     
   Scenario: Admins should be able to add new radio button
     Given I am logged in as an admin

--- a/lib/extensions/couchrest/custom_fields_validator.rb
+++ b/lib/extensions/couchrest/custom_fields_validator.rb
@@ -57,6 +57,22 @@ module CouchRest
         "#{field[:display_name]} cannot be more than #{MAX_LENGTH} characters long"
       end
     end
+
+    class DateFieldsValidator < CustomFieldsValidator
+      # Blackberry client can only parse specific date formats
+      def is_not_valid value
+        begin
+          Date.strptime(value, '%d %b %Y')
+          false
+        rescue
+          true
+        end
+      end
+      def validation_message_for field
+        "#{field[:display_name]} must be formatted as dd M yy (e.g. 4 Feb 2010)"
+      end
+    end
+
     
     module ValidatesCustomFields
 
@@ -73,6 +89,8 @@ module CouchRest
             CouchRest::Validation::CustomTextFieldsValidator
           when Field::TEXT_AREA
             CouchRest::Validation::CustomTextAreasValidator
+          when Field::DATE_FIELD
+            CouchRest::Validation::DateFieldsValidator
         else
           raise "Unrecognised field type " + field_type.to_s + " for validation"
         end

--- a/spec/models/child_spec.rb
+++ b/spec/models/child_spec.rb
@@ -201,6 +201,21 @@ describe Child do
       child.should be_valid
     end
 
+    it "should disallow date fields not formatted as dd M yy" do
+      FormSection.stub!(:all_enabled_child_fields =>
+          [Field.new(:type => Field::DATE_FIELD, :name => "a_datefield", :display_name => "A datefield")])
+      child = Child.new :a_datefield => ('2/27/2010')
+      child.should_not be_valid
+      child.errors[:a_datefield].should == ["A datefield must be formatted as dd M yy (e.g. 4 Feb 2010)"]
+    end
+
+    it "should allow date fields formatted as dd M yy" do
+      FormSection.stub!(:all_enabled_child_fields =>
+          [Field.new(:type => Field::DATE_FIELD, :name => "a_datefield", :display_name => "A datefield")])
+      child = Child.new :a_datefield => ('27 Feb 2010')
+      child.should be_valid
+    end
+
     it "should not validate fields that were not filled in" do
       FormSection.stub!(:all_enabled_child_fields =>
           [Field.new(:type => Field::TEXT_FIELD, :name => "name"),


### PR DESCRIPTION
When a custom date field is populated in the web app the format used currently is not handled by the BB client.  As a result the date shows up incorrectly.  Changed format for custom date field to be 'dd M yy' (e.g. 4 Feb 2011) since this is one of the few formats that the BB HttpDateParser class can handle.
