### PR TITLE
# 547

### DIFF
--- a/app/models/child.rb
+++ b/app/models/child.rb
@@ -175,7 +175,7 @@ class Child < CouchRestRails::Document
   protected
 
   def current_formatted_time
-    Time.now.strftime("%d/%m/%Y %H:%M")
+    Time.now.getutc.strftime("%Y-%m-%d %H:%M:%S%Z")
   end
 
   def changes_for(field_names)

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -10,6 +10,13 @@ When /^the date\/time is "([^\"]*)"$/ do |datetime|
   Time.stub!(:now).and_return current_time
 end
 
+When /^the local date\/time is "([^\"]*)" and UTC time is "([^\"]*)"$/ do |datetime, utcdatetime|
+  current_time = Time.parse(datetime)
+  current_time_in_utc = Time.parse(utcdatetime)
+  Time.stub!(:now).and_return current_time
+  current_time.stub!(:getutc).and_return current_time_in_utc
+end
+
 Given /^someone has entered a child with the name "([^\"]*)"$/ do |child_name|
   visit path_to('new child page')
   fill_in('Name', :with => child_name)

--- a/features/view_child_record_log.feature
+++ b/features/view_child_record_log.feature
@@ -16,11 +16,11 @@ Feature:
     And I choose "Male"
     And I fill in "Haiti" for "Last known location"
     And I attach the file "features/resources/jorge.jpg" to "photo"
-    And the date/time is "July 19 2010 13:05"
+    And the local date/time is "July 19 2010 13:05" and UTC time is "July 19 2010 17:05UTC"
     And I press "Save"
     And I follow "View the change log"
 
-    Then I should see "19/07/2010 13:05 Record created by harry"
+    Then I should see "2010-07-19 17:05:00UTC Record created by harry"
 
   Scenario:  I log in as a different user, upload a new photo and view the record log
 
@@ -28,7 +28,7 @@ Feature:
     And the following children exist in the system:
     | name       | age | age_is | gender | last_known_location |
     | Jorge Just | 27  | Exact  | Male   | Haiti               |
-    And the date/time is "Sept 29 2010 17:59:33"
+    And the local date/time is "Sept 29 2010 17:59:33" and UTC time is "Sept 29 2010 21:59:33UTC"
     And "Mary" is logged in
     And I am on the children listing page
 
@@ -37,7 +37,7 @@ Feature:
     And I press "Save"
     And I follow "View the change log"
 
-    Then I should see "29/09/2010 17:59 Photo changed from"
+    Then I should see "2010-09-29 21:59:33UTC Photo changed from"
     And I should see the thumbnail of "Jorge Just" with key "photo-2010-07-19T130532"
     And I should see the thumbnail of "Jorge Just" with key "photo-2010-09-29T175933"
     And I should see "by mary"
@@ -73,18 +73,18 @@ Feature:
     And I fill in "Bombay" for "Origin"
     And I fill in "Zambia" for "Last known location"
     And I select "6 months to 1 year ago" from "Date of separation"
-    And the date/time is "Oct 29 2010 10:12:15"
+    And the local date/time is "Oct 29 2010 10:12:15" and UTC time is "Oct 29 2010 14:12:15UTC"
     And I press "Save"
 
     When I follow "View the change log"
 
-    Then I should see "29/10/2010 10:12 Last known location changed from Haiti to Zambia by bobby"
-    And I should see "29/10/2010 10:12 Origin initially set to Bombay by bobby"
-    And I should see "29/10/2010 10:12 Age changed from 27 to 56 by bobby"
-    And I should see "29/10/2010 10:12 Name changed from Jorge Just to George Harrison by bobby"
-    And I should see "29/10/2010 10:12 Date of separation initially set to 6 months to 1 year ago by bobby"
-    And I should see "29/10/2010 10:12 Gender changed from Male to Female by bobby"
-    And I should see "29/10/2010 10:12 Age is changed from Exact to Approximate"
+    Then I should see "2010-10-29 14:12:15UTC Last known location changed from Haiti to Zambia by bobby"
+    And I should see "2010-10-29 14:12:15UTC Origin initially set to Bombay by bobby"
+    And I should see "2010-10-29 14:12:15UTC Age changed from 27 to 56 by bobby"
+    And I should see "2010-10-29 14:12:15UTC Name changed from Jorge Just to George Harrison by bobby"
+    And I should see "2010-10-29 14:12:15UTC Date of separation initially set to 6 months to 1 year ago by bobby"
+    And I should see "2010-10-29 14:12:15UTC Gender changed from Male to Female by bobby"
+    And I should see "2010-10-29 14:12:15UTC Age is changed from Exact to Approximate"
     # Order tested at the moment in the show.html.erb_spec.rb view test for histories
 
   Scenario: Clicking back from the change log

--- a/spec/controllers/children_controller_spec.rb
+++ b/spec/controllers/children_controller_spec.rb
@@ -116,15 +116,17 @@ describe ChildrenController do
     end
 
     it "should update history on photo update" do
-      current_time = Time.parse("Jan 20 2010 17:10:32")
+      current_time_in_utc = Time.parse("20 Jan 2010 17:10:32UTC")
+      current_time = Time.parse("20 Jan 2010 17:10:32")
       Time.stub!(:now).and_return current_time
+      current_time.stub!(:getutc).and_return current_time_in_utc
       child = Child.create('last_known_location' => "London", 'photo' => uploadable_photo_jeff)
 
       put :update_photo, :id => child.id, :child => {:photo_orientation => "-180"}
 
       history = Child.get(child.id)["histories"].first
       history['changes'].should have_key('current_photo_key')
-      history['datetime'].should == current_time.strftime('%d/%m/%Y %H:%M')
+      history['datetime'].should == "2010-01-20 17:10:32UTC"
     end
   end
 

--- a/spec/models/child_spec.rb
+++ b/spec/models/child_spec.rb
@@ -110,11 +110,13 @@ describe Child do
     end
 
     it "should populate last_updated_at field with the time of the update" do
-      current_time = Time.parse("Jan 17 2010 14:05")
+      current_time_in_utc = Time.parse("17 Jan 2010 19:05UTC")
+      current_time = mock()
       Time.stub!(:now).and_return current_time
+      current_time.stub!(:getutc).and_return current_time_in_utc
       child = Child.new
       child.update_properties_with_user_name "jdoe", nil, nil, {}
-      child['last_updated_at'].should == "17/01/2010 14:05"
+      child['last_updated_at'].should == "2010-01-17 19:05:00UTC"
     end
 
     it "should update attachments when there is a photo update" do
@@ -355,10 +357,12 @@ describe Child do
     end
 
     it "should create a created_at field with time of creation" do
-      current_time = Time.parse("14 Jan 2010 14:05")
+      current_time_in_utc = Time.parse("14 Jan 2010 14:05UTC")
+      current_time = mock()
       Time.stub!(:now).and_return current_time
+      current_time.stub!(:getutc).and_return current_time_in_utc
       child = Child.new_with_user_name('some_user', 'some_field' => 'some_value')
-      child['created_at'].should == "14/01/2010 14:05"
+      child['created_at'].should == "2010-01-14 14:05:00UTC"
     end
   end
 


### PR DESCRIPTION
Modifies timestamps (created_at and last_updated_at) for child records to be ISO format (UTC tz).
The BB client has also been modified to use the same formats (https://github.com/jorgej/RapidFTR---BlackBerry-Edition/pull/17)
