### PR TITLE
Bug632 made the help text field a text area instead of text field

### DIFF
--- a/app/views/fields/_common.html.erb
+++ b/app/views/fields/_common.html.erb
@@ -4,7 +4,7 @@
 </p>
 <p>
   <%= f.label :help_text %>
-  <%= f.text_field :help_text %>
+  <%= f.text_area :help_text %>
 </p>
 <p>
   <%= f.label :enabled %>


### PR DESCRIPTION
https://minglehosting.thoughtworks.com/sip/projects/rapidftr/cards/632
