### PR TITLE
#655: Show search/advanced search/child listing links on appropriate page

### DIFF
--- a/app/controllers/advanced_search_controller.rb
+++ b/app/controllers/advanced_search_controller.rb
@@ -2,6 +2,7 @@ class AdvancedSearchController < ApplicationController
 
   def index 
     @forms = FormSection.all
+    @aside = 'shared/sidebar_links'
     
     if params[:criteria_list]
       @criteria_list = SearchCriteria.build_from_params params[:criteria_list]      

--- a/app/controllers/children_controller.rb
+++ b/app/controllers/children_controller.rb
@@ -7,7 +7,7 @@ class   ChildrenController < ApplicationController
   def index
     @page_name = "Listing children"
     @children = Child.all
-    @aside = 'search_sidebar'
+    @aside = 'shared/sidebar_links'
 
     respond_to do |format|
       format.html # index.html.erb
@@ -148,6 +148,7 @@ class   ChildrenController < ApplicationController
 
   def search
     @page_name = "Child Search"
+    @aside = "shared/sidebar_links"
     if (params[:query])
       @search = Search.new(params[:query]) 
       if @search.valid?    

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -23,7 +23,6 @@ module ApplicationHelper
 
   end
 
-
   def submit_button(name = 'Save')
     content_tag(:p, :class => 'submitButton') do
       submit_tag(name)
@@ -39,6 +38,15 @@ module ApplicationHelper
   def discard_button(path)
     content_tag(:p, :class => 'discardButton') do
       link_to 'Discard', path, :confirm => 'Clicking OK Will Discard Any Unsaved Changes. Click Cancel To Return To The Child Record Instead.'
+    end
+  end
+  
+  def show_sidebar_links
+    sidebar_links = {"View All Children" => children_path, 
+                     "Search" => search_children_path, 
+                     "Advanced Search" => advanced_search_index_path}
+    sidebar_links.select do |_, link|
+      !current_page?(link)
     end
   end
 end

--- a/app/views/children/_search_sidebar.html.erb
+++ b/app/views/children/_search_sidebar.html.erb
@@ -1,5 +1,0 @@
-<h2>Related Links</h2>
-<ul>
-  <li><%= link_to('Search', :search_children) %></li>
-  <li><%= link_to('Advanced Search', :advanced_search_index) %></li>
-</ul>

--- a/app/views/shared/_sidebar_links.html.erb
+++ b/app/views/shared/_sidebar_links.html.erb
@@ -1,0 +1,6 @@
+<h2>Related Links</h2>
+<ul>
+  <% show_sidebar_links.each do |v| %>
+    <li><%= link_to(v.first, v.last) %></li>
+  <% end %>  
+</ul>

--- a/features/sidebar_links.feature
+++ b/features/sidebar_links.feature
@@ -1,0 +1,35 @@
+Feature: So that a user can view sidebar links
+  As a user of the website
+  I want to see the sidebar links
+
+  Background:
+
+    Scenario: Users should be able to navigate 'Search' and 'Advanced Search' links on the 'View All Children' page
+
+      Given I am logged in
+
+      And I am on children listing page
+
+      Then I should see a link to the child search page
+
+      Then I should see a link to the advanced child search page
+
+    Scenario: Users should be able to navigate 'View All Children' and 'Advanced Search' links on the 'Search' page
+
+      Given I am logged in
+
+      And I am on the child search page
+
+      Then I should see a link to the children listing page
+
+      Then I should see a link to the advanced child search page
+
+    Scenario: Users should be able to navigate 'View All Children' and 'Search' links on the 'Advanced Search' page
+
+      Given I am logged in
+
+      And I am on the advanced child search page
+
+      Then I should see a link to the children listing page
+
+      Then I should see a link to the child search page


### PR DESCRIPTION
Wrote cucumber tests for it because it was really difficult to set the 'current_page' within the helper spec since the code is shared across multiple controllers.
