### PR TITLE
API should accept PUT requests for records that are new when the GUID _ID is supplied.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -44,7 +44,7 @@ class ApplicationController < ActionController::Base
 
   # TODO Remove duplication in ApplicationHelper
   def current_user_name
-    session = get_session
+    session = app_session
     return session.user_name unless session.nil?
   end
 

--- a/app/controllers/children_controller.rb
+++ b/app/controllers/children_controller.rb
@@ -111,11 +111,11 @@ class   ChildrenController < ApplicationController
   # PUT /children/1
   # PUT /children/1.xml
   def update
-    @child = Child.get(params[:id])
+    @child = Child.get(params[:id]) || Child.new_with_user_name(current_user_name, params[:child])
+
     new_photo = params[:child].delete(:photo)
     new_audio = params[:child].delete(:audio)
     @child.update_properties_with_user_name(current_user_name, new_photo, new_audio, params[:child])
-
 
     respond_to do |format|
       if @child.save

--- a/spec/controllers/children_controller_spec.rb
+++ b/spec/controllers/children_controller_spec.rb
@@ -145,6 +145,19 @@ describe ChildrenController do
       history['changes'].should have_key('current_photo_key')
       history['datetime'].should == "2010-01-20 17:10:32UTC"
     end
+
+    it "should allow a records ID to be specified to create a new record with a known id" do
+      new_uuid = UUIDTools::UUID.random_create()
+      put :update, :id => new_uuid.to_s,
+        :child => {
+            :id => new_uuid.to_s,
+            :_id => new_uuid.to_s,
+            :last_known_location => "London",
+            :age => "7"
+        }
+      Child.get(new_uuid.to_s)[:unique_identifier].should_not be_nil
+    end
+
   end
 
   describe "GET search" do


### PR DESCRIPTION
Small change to ensure records that are uploaded have their server side unique identifier applied as normal. 
This is required so that offline devices can assign their own GUIDs for records they have created while out of network range. 
