### PR TITLE
[673] Returning a 403 when a device is blacklisted instead of a 401

### DIFF
--- a/app/controllers/checks_authentication.rb
+++ b/app/controllers/checks_authentication.rb
@@ -42,6 +42,6 @@ module ChecksAuthentication
   end
   
   def handle_device_blacklisted(session)
-    render(:status => 401, :json => session.imei)
+    render(:status => 403, :json => session.imei)
   end
 end

--- a/features/step_definitions/api_steps.rb
+++ b/features/step_definitions/api_steps.rb
@@ -25,7 +25,7 @@ When /^I login with user (.+):(.+) for device with imei (.+)$/ do |user, passwor
 end
 
 Then /^should be kill response for imei "(.+)"$/ do |imei|
-  #response.status.should =~ /401/
+  response.status.should =~ /403/
   response_body.should == imei
 end
 

--- a/spec/controllers/checks_authentication_spec.rb
+++ b/spec/controllers/checks_authentication_spec.rb
@@ -121,4 +121,18 @@ describe ChecksAuthentication, :type => :normal do
       exercise_authorization_check
     end
   end
+  
+  describe "Blacklisted" do
+
+    it "should return 403 if a device is blacklisted" do
+      set_session_token_cookie
+      session = Session.new(:imei => "BLAH")
+      session.stub!(:admin?).and_return(true)
+      session.stub!(:device_blacklisted?).and_return(true)
+      Session.stub!(:get).and_return(session)
+      @controller.should_receive(:render).with(:status => 403, :json => session.imei)
+
+      exercise_authentication_check
+    end
+  end
 end


### PR DESCRIPTION
Note for Jen:

The story says "can we throw a 403 if the device is blacklisted and a 401 if it is merely unrecognised!", the assumption is that "unrecognised" means unauthenticated.

Before this story was played, we were returning a 401 for authentication failure (though the method name in error_response.rb:9 could be a typo?), and 403 for authorization failure. So returning a 403 for a blacklisted device would be the same result as an authorization failure. Presumably that's expected?
