### PR TITLE
Story #305: Order of records in the PDF generator

### DIFF
--- a/app/controllers/children_controller.rb
+++ b/app/controllers/children_controller.rb
@@ -161,12 +161,12 @@ class   ChildrenController < ApplicationController
   end
 
   def export_data
-    child_ids = params.map{ |k, v| 'selected' == v ? k : nil }.compact
-    if child_ids.empty?
+    selected_records = params["selections"] || {}
+    if selected_records.empty?
       raise ErrorResponse.bad_request('You must select at least one record to be exported')
     end
-
-    children = child_ids.map{ |child_id| Child.get(child_id) }
+    
+    children = selected_records.sort.map{ |index, child_id| Child.get(child_id) }
 
     if params[:commit] == "Export to Photo Wall"
       export_photos_to_pdf(children, "#{file_basename}.pdf")

--- a/app/views/children/_summary_row.html.erb
+++ b/app/views/children/_summary_row.html.erb
@@ -2,7 +2,7 @@
 <div id="child_<%= summary_row['_id'] %>" class="profiles-list-item">
   <div class="header">
     <p class="checkbox">
-      <%= check_box_tag summary_row['_id'], 'selected' %>
+      <%= check_box_tag "selections[#{summary_row_counter}]", summary_row['_id'] %>
     </p>
 
     <h3><%= link_to summary_row['name'], child_path(summary_row) %></h3>

--- a/spec/controllers/children_controller_spec.rb
+++ b/spec/controllers/children_controller_spec.rb
@@ -18,6 +18,7 @@ end
 
 
 describe ChildrenController do
+  
   before do
     Clock.fake_time_now = Time.utc(2000, "jan", 1, 20, 15, 1)
     fake_login
@@ -202,8 +203,11 @@ describe ChildrenController do
       post(
         :export_data,
         {
-          'child_1' => 'selected',
-          'child_2' => 'selected',
+          :selections => 
+          {
+            '0' => 'child_1',
+            '1' => 'child_2'
+          },
           :commit => "Export to PDF"
         }
       )
@@ -223,8 +227,11 @@ describe ChildrenController do
       post(
         :export_data,
         {
-          'child_1' => 'selected',
-          'child_2' => 'selected',
+          :selections => 
+          {
+            '0' => 'child_1',
+            '1' => 'child_2'
+          },
           :commit => "Export to Photo Wall"
         }
       )
@@ -300,28 +307,20 @@ describe ChildrenController do
   end
 
   describe "GET photo_pdf" do
-    it 'extracts a single selected id from post params correctly' do
-      stub_out_pdf_generator
-      Child.should_receive(:get).with('a_child_id')
-      post(
-        :export_data,
-        { 'a_child_id' => 'selected', 'some_other_post_param' => 'blah' }
-      )
-    end
 
-    it 'extracts a multiple selected ids from post params correctly' do
+    it 'extracts multiple selected ids from post params in correct order' do
       stub_out_pdf_generator
-      Child.should_receive(:get).with('child_one')
-      Child.should_receive(:get).with('child_two')
-      Child.should_receive(:get).with('child_three')
+      Child.should_receive(:get).with('child_zero').ordered
+      Child.should_receive(:get).with('child_one').ordered
+      Child.should_receive(:get).with('child_two').ordered
 
       post(
         :export_data,
+        :selections => 
         {
-          'child_one' => 'selected',
-          'child_two' => 'selected',
-          'child_three' => 'selected',
-          'some_other_post_param' => 'blah'
+          '2' => 'child_two',
+          '0' => 'child_zero',
+          '1' => 'child_one'
         }
       )
     end
@@ -338,7 +337,7 @@ describe ChildrenController do
         should_receive(:send_data).
         with( :fake_pdf_data, :filename => "foo-user-20000101-2015.pdf", :type => "application/pdf" )
 
-      post( :export_data, 'ignored' => 'selected', :commit => "Export to Photo Wall" )
+      post( :export_data, :selections => {'0' => 'ignored'}, :commit => "Export to Photo Wall" )
     end
   end
 

--- a/spec/views/child/search.html.erb_spec.rb
+++ b/spec/views/child/search.html.erb_spec.rb
@@ -55,7 +55,8 @@ describe "children/search.html.erb" do
       select_check_boxes = Hpricot(response.body).checkboxes
       select_check_boxes.length.should == @results.length
       select_check_boxes.each_with_index do |check_box,i|
-        check_box['name'].should == @results[i]['_id']
+        check_box['name'].should == "selections[#{i}]"
+        check_box['value'].should == @results[i]['_id']
       end
     end
 	


### PR DESCRIPTION
Story #305 - Farooq: Sort order of exported records now matches the order of search results. Needed to preserve the order of results in the checkboxes, which also led to cleaner controller code for the export
