### PR TITLE
Adding fix to issue with potential DOS attack.

### DIFF
--- a/app/controllers/child_media_controller.rb
+++ b/app/controllers/child_media_controller.rb
@@ -8,6 +8,9 @@ class ChildMediaController < ApplicationController
 
   def show_resized_photo
     new_size = params[:size]
+    if new_size.to_i > 3000 then
+      new_size = 640
+    end
     photo_data = @attachment.data.read
     resized_photo = MiniMagick::Image.from_blob(photo_data).resize new_size
     send_data(resized_photo.to_blob, :type => @attachment.content_type, :disposition => 'inline')


### PR DESCRIPTION
If you issue a request to a server for a huge image, the entire server stops responding temporarily while it deals with resizing the image. I've set the max size to 3000, defaulting to 640 if somebody tries to go for larger.
