### PR TITLE
[ToyC] #643 fixed missing up arrow on the second row

### DIFF
--- a/public/javascripts/form_section.js
+++ b/public/javascripts/form_section.js
@@ -13,7 +13,7 @@ function initOrderingColumns() {
 		$("a.moveUp", element).show();
 	});
 	
-	var fieldToStartFrom = 2;
+	var fieldToStartFrom = 1;
 
 	$("#form_sections tbody tr:nth-child("+fieldToStartFrom+")").each(function(index, element){
 		$("a.moveDown", element).show();


### PR DESCRIPTION
I fixed the issue, the up arrow is showing on the second row now. 
