### PR TITLE
#755 Fix: Page names, Window names, Link names not matching

### DIFF
--- a/app/controllers/advanced_search_controller.rb
+++ b/app/controllers/advanced_search_controller.rb
@@ -10,6 +10,7 @@ class AdvancedSearchController < ApplicationController
   end
 
   def index
+    @page_name = "Advanced Search"
     @forms = FormSection.by_order
     @aside = 'shared/sidebar_links'
     @highlighted_fields = []

--- a/app/controllers/children_controller.rb
+++ b/app/controllers/children_controller.rb
@@ -6,7 +6,7 @@ class ChildrenController < ApplicationController
   # GET /children
   # GET /children.xml
   def index
-    @page_name = "Listing children"
+    @page_name = "View All Children"
     @children = Child.all
     @aside = 'shared/sidebar_links'
     
@@ -29,7 +29,7 @@ class ChildrenController < ApplicationController
 
     @form_sections = get_form_sections
 
-    @page_name = @child
+    @page_name = "View Child: #{@child}"
 
     @aside = 'picture'
     @body_class = 'profile-page'
@@ -52,7 +52,7 @@ class ChildrenController < ApplicationController
   # GET /children/new
   # GET /children/new.xml
   def new
-    @page_name = "New child record"
+    @page_name = "Register New Child"
     @child = Child.new
     @form_sections = get_form_sections
     respond_to do |format|
@@ -63,7 +63,7 @@ class ChildrenController < ApplicationController
 
   # GET /children/1/edit
   def edit
-    @page_name = "Edit child record"
+    @page_name = "Edit Child"
     @form_sections = get_form_sections
   end
 
@@ -143,7 +143,7 @@ class ChildrenController < ApplicationController
   end
 
   def search
-    @page_name = "Child Search"
+    @page_name = "Search"
     @aside = "shared/sidebar_links"
     if (params[:query])
       @search = Search.new(params[:query]) 

--- a/app/controllers/contact_information_controller.rb
+++ b/app/controllers/contact_information_controller.rb
@@ -5,7 +5,8 @@ class ContactInformationController < ApplicationController
 
   # GET /contact_information/Administrator  
   def show
-    @contact_information = ContactInformation.get_by_id(params[:id]) 
+    @page_name = "Contact & Help"
+    @contact_information = ContactInformation.get_by_id(params[:id])
     respond_to do |format|
       format.html # index.html.erb
       format.json { render :json => @contact_information }
@@ -14,6 +15,7 @@ class ContactInformationController < ApplicationController
 
   # GET /contact_information/Administrator/edit
   def edit
+    @page_name = "Edit Contact Information"
     @contact_information = ContactInformation.get_or_create(params[:id])
   end
   

--- a/app/controllers/fields_controller.rb
+++ b/app/controllers/fields_controller.rb
@@ -13,6 +13,7 @@ class FieldsController < ApplicationController
     @body_class = 'forms-page'
     @suggested_fields = SuggestedField.all_unused
     @field = Field.new(:type => params[:type])
+    @page_name = "New #{@field.type.humanize}"
     render params[:fieldtype]
   end
   

--- a/app/controllers/form_section_controller.rb
+++ b/app/controllers/form_section_controller.rb
@@ -3,6 +3,7 @@ class FormSectionController < ApplicationController
   before_filter :administrators_only
 
   def index
+    @page_name = "Manage Form Sections"
     @form_sections = FormSection.all.sort_by { |row| [row.enabled ? 0 : 1, row.order] }
   end
 
@@ -23,6 +24,7 @@ class FormSectionController < ApplicationController
   end
   
   def edit
+    @page_name = "Edit Form Sections"
     @form_section = FormSection.get_by_unique_id(params[:id])
   end
   
@@ -59,6 +61,7 @@ class FormSectionController < ApplicationController
   end
   
   def new
+    @page_name = "Create New Form Section"
     @form_section = FormSection.new(params[:form_section])
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -19,6 +19,7 @@ class UsersController < ApplicationController
   end
 
   def new
+    @page_name = 'New User'
     @user = User.new
   end
 
@@ -26,7 +27,8 @@ class UsersController < ApplicationController
     session = app_session
     
     @user = User.get(params[:id])
-    unless session.admin? or @user.user_name == current_user_name   
+    @page_name = "Editing User: #{@user.full_name}"
+    unless session.admin? or @user.user_name == current_user_name
       raise AuthorizationFailure.new('Not permitted to view page')
     end
   end

--- a/app/views/admin/index.html.erb
+++ b/app/views/admin/index.html.erb
@@ -2,7 +2,7 @@
     <%= link_to 'Manage Children', children_path %>
 </p>
 <p>
-    <%= link_to 'Manage Forms', formsections_path  %>
+    <%= link_to 'Manage Form Sections', formsections_path  %>
 </p>
 <p>
     <%= link_to 'Manage Users', users_path %>

--- a/app/views/children/index.html.erb
+++ b/app/views/children/index.html.erb
@@ -1,6 +1,6 @@
 <h2>All children</h2>
 
-<p><%= link_to 'New child', new_child_path %></p>
+<p><%= link_to 'Register New Child', new_child_path %></p>
 
 <%= render :partial => "children/summary_row", :collection => @children, :locals => { :checkbox => false } %>
 

--- a/app/views/contact_information/edit.html.erb
+++ b/app/views/contact_information/edit.html.erb
@@ -1,5 +1,3 @@
-<% @page_name = "Editing contact information" %>
-
 <% form_for @contact_information, :url => contact_information_path(@contact_information.id), :html => {:class=> 'default-form'} do |f| %>
   <fieldset>
     <h3>Contact Information</h3>

--- a/app/views/contact_information/show.html.erb
+++ b/app/views/contact_information/show.html.erb
@@ -1,4 +1,3 @@
-<% @page_name = "Administrator Contact Information" %>
 <p>If you experience any problems with RapidFTR, or believe your password has been exposed, please contact the system administrator immediately.</p>
      <%= show_contact_field :name %>
      <%= show_contact_field :position %>

--- a/app/views/fields/new.html.erb
+++ b/app/views/fields/new.html.erb
@@ -1,2 +1,1 @@
-<% @page_name = "New #{@field.type.humanize}" %>
 <%= render :partial => "#{@field.form_type}_form", :locals=> { :url => formsection_fields_path } %>

--- a/app/views/form_section/edit.html.erb
+++ b/app/views/form_section/edit.html.erb
@@ -1,4 +1,3 @@
-<% @page_name = 'Edit form' %>
 <% form_for @form_section, :url => form_section_path(@form_section.unique_id), :html => { :class => "edit-form-section default-form" } do |f| %>
 
 <fieldset>

--- a/app/views/form_section/index.html.erb
+++ b/app/views/form_section/index.html.erb
@@ -1,6 +1,4 @@
-<h2>Manage form sections</h2>
-
-<p><%= link_to 'Create form', new_form_section_path %></p>
+<p><%= link_to 'Create New Form Section', new_form_section_path %></p>
 
 <% form_tag  enable_form_url, :id => 'enable_or_disable_form_section', :method => :post, :name => 'sections'  do -%>
 

--- a/app/views/form_section/new.html.erb
+++ b/app/views/form_section/new.html.erb
@@ -1,5 +1,3 @@
-<% @page_name = 'Create form' %>
-
 <p>We encourage you to use the existing forms as this makes data sharing and data merging between institutions easier.</p>
 
 <%= error_messages_for  :form_section,

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -11,5 +11,5 @@
       </p>
   <% end %>
 </p>
-<%= link_to 'Register Child', new_child_path %> <br/><br/>
+<%= link_to 'Register New Child', new_child_path %> <br/><br/>
 <%= link_to 'View All Children', children_path %> <br/><br/>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,7 +4,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
   <meta http-equiv="content-type" content="text/html;charset=UTF-8"/>
-  <title><%= controller.name %>: <%= controller.action_name %></title>
+  <title><%= @page_name %></title>
   <link rel="shortcut icon" href="/favicon.ico" />
   <%= stylesheet_link_tag 'core' %>
   <%= stylesheet_link_tag 'overcast/jquery-ui-1.8.6.custom.css' %>
@@ -38,7 +38,7 @@
             <% unless !is_admin? %>
                         <li><%= link_to 'Admin', admin_path %></li>
 			<% end %>
-        <li><%= link_to('Search Children', :search_children) %></li>
+        <li><%= link_to('Search', :search_children) %></li>
 	<li><%= link_to('Account', edit_user_path(User.find_by_user_name(current_user_name))) %></li>
         <% end %>
       </ul>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,5 +1,3 @@
-<% @page_name = "Editing user: #{@user.full_name}" %>
-
 <%= render :partial => "edittable_user", :object => @user %>
 <% unless !is_admin? %>
 <%= render :partial => "mobile_login_history", :object => @user %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,3 +1,1 @@
-<% @page_name = 'New User' %>
-
 <%= render :partial => "edittable_user", :object => @user %>

--- a/features/add_custom_field_to_form_section.feature
+++ b/features/add_custom_field_to_form_section.feature
@@ -35,7 +35,7 @@ Feature: So that admin can customize fields in a form section
     
     Then I should see "Anything"
     When I am on children listing page
-    And I follow "New child"
+    And I follow "Register New Child"
     
     Then I should see "Anything"
        
@@ -62,7 +62,7 @@ Feature: So that admin can customize fields in a form section
     Then I should see "Anything"
 
     When I am on children listing page
-    And I follow "New child"
+    And I follow "Register New Child"
 
     Then I should see "Anything"
     When I fill in "17 Nov 2010" for "child_anything"
@@ -97,7 +97,7 @@ Feature: So that admin can customize fields in a form section
   
   Then I should see "Radio button name"
   When I am on children listing page
-  And I follow "New child"
+  And I follow "Register New Child"
   
   Then I should see "Radio button name" 
   
@@ -147,7 +147,7 @@ Feature: So that admin can customize fields in a form section
     And I should see "my_new_number_field" in the list of fields
 
     When I am on children listing page
-    And I follow "New child"
+    And I follow "Register New Child"
     And I fill in "2345" for "My new number field"
     And I press "Save"
 

--- a/features/add_suggested_field_to_form_sections.feature
+++ b/features/add_suggested_field_to_form_sections.feature
@@ -49,7 +49,7 @@ Feature: Adding a suggested field to a form section
      Then I should see "Field successfully added"
 
      When I am on children listing page
-     And I follow "New child"
+     And I follow "Register New Child"
 
      Then I should see the select named "child[field_with_options]"
      And I should see an option "option1" for select "child[field_with_options]"

--- a/features/child_record_validations.feature
+++ b/features/child_record_validations.feature
@@ -5,7 +5,7 @@ Scenario: Should be restricted to 200 characters in a text field
 
   Given I am logged in
   And I am on children listing page
-  And I follow "New child"
+  And I follow "Register New Child"
   When I fill in a 201 character long string for "Name" 
   And I press "Save" 
   Then I should see "Name cannot be more than 200 characters long"	
@@ -20,7 +20,7 @@ Scenario: Should be restricted to 400,000 characters in a text area
 		| my_text_area | textarea | my text area |
 	Given I am logged in
 	And I am on children listing page
-	And I follow "New child"
+	And I follow "Register New Child"
 	When I fill in a 400001 character long string for "my text area" 
 	And I press "Save" 
 	Then I should see "my text area cannot be more than 400000 characters long"
@@ -29,7 +29,7 @@ Scenario: Should be restricted to 400,000 characters in a text area
 Scenario: Should be prevented from saving a record that has no data filled in
 	Given I am logged in
 	And I am on children listing page
-	And I follow "New child"
+	And I follow "Register New Child"
 	And I press "Save" 
 	Then I should see "Please fill in at least one field or upload a file"
   And there should be 0 child records in the database

--- a/features/create_child_new_disabled_form_section.feature
+++ b/features/create_child_new_disabled_form_section.feature
@@ -10,7 +10,7 @@ Feature: As an user I should not see disabled forms when adding new child
       | Caregiver Details   |  | caregiver_details | 3 | true |
       | Disabled |  | disabled_details | 4 | false |
     And I am on children listing page
-    And I follow "New child"
+    And I follow "Register New Child"
 
     Then I should see the "Basic Details" tab
     And I should see the "Family Details" tab

--- a/features/create_child_record.feature
+++ b/features/create_child_record.feature
@@ -5,7 +5,7 @@ Feature:
   Scenario: creating a child record
     Given I am logged in
     And I am on children listing page
-    And I follow "New child"
+    And I follow "Register New Child"
 
     When I fill in "Jorge Just" for "Name"
     And I fill in "27" for "Date of Birth / Age"
@@ -25,18 +25,18 @@ Feature:
 
     When I follow "Back"
 
-    Then I should see "Listing children"
+    Then I should see "View All Children"
     And I should see "Jorge Just"
     And I should see "View"
 
     When I follow "Jorge Just"
     Then I follow "Back"
-    And I should see "Listing children"
+    And I should see "View All Children"
     And I should see "Jorge Just"
 
     When I follow "View"
     Then I follow "Back"
-    And I should see "Listing children"
+    And I should see "View All Children"
     And I should see "Jorge Just"
 
   Scenario: create child with approximate age

--- a/features/create_new_form.feature
+++ b/features/create_new_form.feature
@@ -14,7 +14,7 @@ Feature: Create new forms
   Scenario: User creates a new form and it is added to the bottom of the list of forms
 
     Given I am on form section page
-    And I follow "Create form"
+    And I follow "Create New Form Section"
     And I fill in "form_section_name" with "New Form 1"
     And I fill in "form_section_description" with "I am a new custom form.  Say hello!"
 
@@ -28,7 +28,7 @@ Feature: Create new forms
   Scenario: Disallowing non alphanumeric characters in the name field
 
     Given I am on form section page
-    And I follow "Create form"
+    And I follow "Create New Form Section"
     And I fill in "form_section_name" with "This is D£dgy"
     And I fill in "form_section_description" with "I am a new custom form.  Say hello!"
 
@@ -39,7 +39,7 @@ Feature: Create new forms
   Scenario: Name field cannot be empty
 
     Given I am on form section page
-    And I follow "Create form"
+    And I follow "Create New Form Section"
     And I fill in "form_section_description" with "I am a new custom form.  Say hello!"
 
     When I press "Save Form"
@@ -49,7 +49,7 @@ Feature: Create new forms
   Scenario: Cancelling the creation of a form
 
     Given I am on form section page
-    And I follow "Create form"
+    And I follow "Create New Form Section"
     And I fill in "form_section_name" with "New Form 1"
     And I fill in "form_section_description" with "I am a new custom form.  Say hello!"
 
@@ -61,7 +61,7 @@ Feature: Create new forms
   Scenario: Can create a form section disabled
 
     Given I am on form section page
-    And I follow "Create form"
+    And I follow "Create New Form Section"
 	Then I should see "Visible checkbox" with id "form_section_enabled"
     And I fill in "form_section_name" with "New Form 1"
     And I uncheck "Visible"

--- a/features/edit_child_record.feature
+++ b/features/edit_child_record.feature
@@ -9,7 +9,7 @@ Feature:
 
     # creating a record
     Given I am on children listing page
-    And I follow "New child"
+    And I follow "Register New Child"
 
     When I fill in "Jorge Just" for "Name"
     And I fill in "27" for "Date of Birth / Age"

--- a/features/hide_child_record_form_fields.feature
+++ b/features/hide_child_record_form_fields.feature
@@ -26,7 +26,7 @@ Feature: Hide Child Record Form Fields
   Scenario: Hidden field does not appear of form
    Given I follow "Home"
      And I am on children listing page
-     And I follow "New child"
+     And I follow "Register New Child"
      And I fill in "Name" with "Will"
     When I press "Save"
     Then I should see "Child record successfully created."
@@ -38,7 +38,7 @@ Feature: Hide Child Record Form Fields
   Scenario: Hidden field does not appear on PDF
    Given I follow "Home"
      And I am on children listing page
-     And I follow "New child"
+     And I follow "Register New Child"
      And I fill in "Name" with "Will"
     When I press "Save"
     Then I follow "Export to PDF"

--- a/features/home_page_link.feature
+++ b/features/home_page_link.feature
@@ -21,5 +21,5 @@ Feature: So that a user can get back to their initial start page from anywhere w
 
     Given I am on the home page
     Then I should see "Welcome to RapidFTR"
-    And I should see "Register Child"
+    And I should see "Register New Child"
     And I should see "View All Children"

--- a/features/manage_forms.feature
+++ b/features/manage_forms.feature
@@ -1,10 +1,10 @@
-Feature: So that admin can see Manage Forms Page
+Feature: So that admin can see Manage Form Sections Page
 
   Background:
     Given I am logged in as an admin
     And I follow "Admin"
     And I create a new form called "Other details"
-    And I follow "Manage Forms"
+    And I follow "Manage Form Sections"
 
   Scenario: Admins should see correct re-ordering links for each section
     Then I should see the "basic_identity" section without any ordering links

--- a/features/user_disable.feature
+++ b/features/user_disable.feature
@@ -46,6 +46,6 @@ Feature:
     And I am on the children listing page
 
     When user "george" is disabled
-    And I follow "New child"
+    And I follow "Register New Child"
 
     Then I should have received a "401 Unauthorized" status code

--- a/features/view_child_record_log.feature
+++ b/features/view_child_record_log.feature
@@ -8,7 +8,7 @@ Feature:
 
     Given "Harry" is logged in
     And I am on the children listing page
-    And I follow "New child"
+    And I follow "Register New Child"
 
     When I fill in "Jorge Just" for "Name"
     And I fill in "27" for "Date of Birth / Age"

--- a/spec/controllers/fields_controller_spec.rb
+++ b/spec/controllers/fields_controller_spec.rb
@@ -2,7 +2,7 @@
 require 'spec_helper'
 
 def should_populate_form_section(action)
-  get action, :formsection_id => @form_section.unique_id
+  get action, :formsection_id => @form_section.unique_id, :type => "text_field"
   assigns[:form_section].should == @form_section
 end
 
@@ -24,7 +24,7 @@ describe FieldsController do
      it "populates suggested fields with all unused suggested fields" do
        suggested_fields = [SuggestedField.new, SuggestedField.new, SuggestedField.new]
        SuggestedField.stub!(:all_unused).and_return(suggested_fields)
-       get :new, :formsection_id=>@form_section.unique_id
+       get :new, :formsection_id=>@form_section.unique_id, :type => "text_field"
        assigns[:suggested_fields].should == suggested_fields
      end
      

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -45,7 +45,7 @@ describe UsersController do
 
   describe "GET edit" do
     it "assigns the requested user as @user" do
-      User.stub!(:get).with("37").and_return(mock_user)
+      User.stub!(:get).with("37").and_return(mock_user(:full_name => "Test Name"))
       get :edit, :id => "37"
       assigns[:user].should equal(mock_user)
     end
@@ -123,7 +123,7 @@ describe UsersController do
       fake_session.stub(:admin?).with(no_args()).and_return(false)
       fake_session.stub(:user_name).and_return('me')
       Session.stub(:get).and_return(fake_session)
-      User.stub!(:get).with("37").and_return(mock_user)
+      User.stub!(:get).with("37").and_return(mock_user(:full_name => "Test Name"))
       mock_user.should_receive(:user_name).with(no_args()).and_return('not-self')
       controller.should_receive(:handle_authorization_failure).with(anything).and_return(anything)
       get :edit, :id => "37"
@@ -134,7 +134,7 @@ describe UsersController do
       fake_session.stub(:admin?).with(no_args()).and_return(false)
       fake_session.stub(:user_name).and_return('fakeuser')
       Session.stub(:get).and_return(fake_session)
-      User.stub!(:get).with("24").and_return(mock_user)
+      User.stub!(:get).with("24").and_return(mock_user(:full_name => "Test Name"))
       mock_user.should_receive(:user_name).with(no_args()).and_return('fakeuser')
       controller.should_not_receive(:handle_authorization_failure).with(anything).and_return(anything)
       get :edit, :id => "24"


### PR DESCRIPTION
Pull this soon: contains a lot of small changes in many different pages

---
#755: Fix:  Page names, Window names, Link names not matching (Ilias)

The name of a link a user clicks on doesn't match the page title that the user is taken to or the window title.

For example, from the Home page, the user can click on View All Children link and the page that opens is called "Listing Children" and the window title says "Children: index". I would haave expected the page title and window title to be both "View All Children".

Other cases would be: Edit child (Expected: "Edit Child Record"), New Child (Expected: "New Child Record"), Search children (Expected: "Search"). Advanced Search page doesn't have a page title, and the window title is AdvancedSearch one word.
