### PR TITLE
420 - limit character on form field names

### DIFF
--- a/app/views/form_section/edit.html.erb
+++ b/app/views/form_section/edit.html.erb
@@ -56,7 +56,7 @@
         <span class="enabledStatus"><%= field.enabled? ? "Visible" : "Hidden" %></span>
       </td>
       <% end %>
-      <td><%= field.display_name %></td>
+      <td class='breakword'><%= field.display_name %></td>
       <%if @form_section.editable?%>
       <td>
 	<div>

--- a/public/stylesheets/core.css
+++ b/public/stylesheets/core.css
@@ -270,6 +270,8 @@ div.formSectionButtons { overflow:hidden; }
 div.formSectionButtons input { font-size: .75em; margin-top: 5px;}
 div.backLink { font-size: 1em; margin-left: 5px; margin-top: 5px;}
 tr.rowDisabled {  font-style: italic; }
+td.breakword {word-wrap:break-word;max-width:100px;}
+
 /* fields list page */
 .direction-button, .delete-button { display:none }
 


### PR DESCRIPTION
Original bug said to limit the number of characters on form field names, but it is more easily (and consistently) solved by setting CSS to break long words at width boundaries. 
