### PR TITLE
#548: password_confirmation field not highlighted when it is blank

### DIFF
--- a/app/views/users/_edittable_user.html.erb
+++ b/app/views/users/_edittable_user.html.erb
@@ -7,7 +7,7 @@
     });
     return true;
   }
-  
+
   function confirmDisable() {
     var checkbox = $("#user_disabled")[0];
     if (checkbox.checked && !checkbox.defaultChecked) {
@@ -15,7 +15,7 @@
     }
     return true;
   }
-  
+
   $(document).ready(function() {
     $("form").submit(function() { return (confirmDisable() && confirmBlacklisted()); } );
   });


### PR DESCRIPTION
Fix defect #548: password_confirmation field not highlighted when it is blank.

when "Re-enter password" is blank, it will now highlighted it red when trying to save.
