### PR TITLE
hide close button in modal popup box for disabling/enabling user

### DIFF
--- a/public/javascripts/manage_users.js
+++ b/public/javascripts/manage_users.js
@@ -89,6 +89,8 @@ ManageUsers.init = function () {
   $('#modal-dialog').dialog({
     autoOpen: false,
     modal: true,
+    closeOnEscape: false,
+    open: function(event, ui){ $('.ui-dialog-titlebar-close', ui.dialog).hide(); },
     buttons: {
       "Yes" : function() {
         var opt = $(this).dialog('option');
@@ -102,7 +104,6 @@ ManageUsers.init = function () {
       }
     }
   });
-
 
 };
 


### PR DESCRIPTION
Could not replicate the issue,
but close button doesn't reset the checkbox state, so we disable close button and closeOnEscape
