### PR TITLE
Rune/Hume: Pull request for story #1162

### DIFF
--- a/app/controllers/children_controller.rb
+++ b/app/controllers/children_controller.rb
@@ -152,15 +152,6 @@ class ChildrenController < ApplicationController
       format.json { render :json => {:response => "ok"}.to_json }
     end
   end
-  
-  # GET /children/suspect_records
-  def suspect_records
-    @page_name = "Suspect Records"
-    @children = Child.suspect_records
-    respond_to do |format|
-      format.html { @highlighted_fields = FormSection.sorted_highlighted_fields }
-    end
-  end
 
   def search
     @page_name = "Search"
@@ -300,7 +291,7 @@ class ChildrenController < ApplicationController
   
   def filter_flagged_children
     @order ||= 'most recently flagged'
-    @children = Child.all.select{ |c| c.flag? }
+    @children = Child.flagged
     @children.each { |child| 
       child['flagged_at'] = child['histories'].select{ |h| h['changes'].keys.include?('flag') }.map{ |h| h['datetime'] }.max
     }

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -4,6 +4,6 @@ class HomeController < ApplicationController
     @page_name = "Home"
     @user = User.find_by_user_name(current_user_name)
     @notifications = PasswordRecoveryRequest.to_display
-    @suspect_record_count = Child.suspect_records.count
+    @suspect_record_count = Child.flagged.count
   end
 end

--- a/app/models/child.rb
+++ b/app/models/child.rb
@@ -135,12 +135,8 @@ class Child < CouchRestRails::Document
     SearchService.search [ SearchCriteria.new(:field => "name", :value => query) ]
   end
   
-  def self.suspect_records
-    records = []
-    self.all.each do |c| 
-      records << c if c.flag? && !c.investigated?
-    end
-    records
+  def self.flagged
+    by_flag(:key => 'true')
   end
 
   def self.new_with_user_name(user_name, fields = {})

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -13,4 +13,4 @@
 </p>
 <%= link_to 'Register New Child', new_child_path %> <br/><br/>
 <%= link_to 'View All Children', children_path %> <br/><br/>
-<%= link_to @suspect_record_count.to_s + ' Records need Attention', suspect_records_children_path %> <br/><br/>
+<%= link_to @suspect_record_count.to_s + ' Records need Attention', child_filter_path("flagged") %> <br/><br/>

--- a/capybara_features/support/paths.rb
+++ b/capybara_features/support/paths.rb
@@ -121,8 +121,8 @@ module NavigationHelpers
       when /all child Ids/
         child_ids_path
         
-      when /suspect records page/i
-        suspect_records_children_path
+      when /the child listing filtered by (.+)/
+        child_filter_path $1
 
       # Add more mappings here.
       # Here is an example that pulls values out of the Regexp:

--- a/capybara_features/suspect_records.feature
+++ b/capybara_features/suspect_records.feature
@@ -1,8 +1,7 @@
 Feature: Suspect records
 
   As an admin
-  I want to be able to mark suspect records as investigated
-  To keep track of flagged records
+  I want to manage flagged records
   
   Background:
   
@@ -13,48 +12,37 @@ Feature: Suspect records
      | Bob    | bob_uid    | true     | bob is dodgy      | false        |
      | Dave   | dave_uid   | true     | dave is dodgy     | true         |
      | George | george_uid | false    | nil               | false        |
-     
+
   Scenario: Admin user should see a link on the home page with the details of how many suspect records need attention
   When I am on the home page
-  Then I should see "2 Records need Attention"
+  Then I should see "3 Records need Attention"
 
   Scenario: Admin user should only see flagged children which have not been investigated
-  When I am on the Suspect Records page
+  When I am on the child listing filtered by flagged
   Then I should see "Steve"
   And I should see "Bob"
-  And I should not see "Dave"
+  And I should see "Dave"
   And I should not see "George"
-  
+
   Scenario: Admin should be able to mark suspect record as investigated
-  When I am on the Suspect Records page
+  When I am on the child listing filtered by flagged
   And I follow "Steve"
   Then I should see "Mark record as Investigated"
-  
-  Scenario: When an admin user marks a flagged record as investigated it should no longer appear on the suspect record page
-  When I am on the Suspect Records page
+
+ 	Scenario: When an admin user marks a flagged record as investigated it should no longer appear on the suspect record page
+  When I am on the child listing filtered by flagged
   And I follow "Steve"
   And I mark "Steve" as investigated with the following details:
     """
     I wouldn't worry about this guy
     """
-  And I am on the Suspect Records page
-  Then I should not see "Steve"
-  
+  Then I should see "Mark as Not Investigated"
+
   Scenario: Admin should be able to mark investigated record as not investigated
   When I am on the children listing page
   And I follow "Dave"
   Then I should see "Mark as Not Investigated"
-  
-  Scenario: When an admin user marks an investigated record as not investigated it should appear on the suspect record page
-  When I am on the children listing page
-  And I follow "Dave"
-  And I mark "Dave" as not investigated with the following details:
-    """
-    I don't know what's going on with this record
-    """  
-  And I am on the Suspect Records page
-  Then I should see "Dave"
-  
+
   Scenario: When a record is not flagged admin should not be able to mark as investigated or not investigated
   When I am on the children listing page
   And I follow "George"
@@ -62,7 +50,7 @@ Feature: Suspect records
   And I should not see "Mark as Not Investigated"
   
   Scenario: When I mark a record as investigated the change log should display a single entry for the change
-  When I am on the Suspect Records page
+  When I am on the child listing filtered by flagged
   And I follow "Steve"
   And I mark "Steve" as investigated with the following details:
     """
@@ -70,7 +58,7 @@ Feature: Suspect records
     """
   And I follow "View the change log"
   Then I should see "Record was marked as Investigated by admin because: I wouldn't worry about this guy"
-  
+
   Scenario: When I mark a record as not investigated the change log should display a single entry for the change
   When I am on the children listing page
   And I follow "Dave"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,8 +4,7 @@ ActionController::Routing::Routes.draw do |map|
                                             :export_photos_to_pdf => :post,
                                             :advanced_search => :get,
                                             :export_csv => :post,
-                                            :export_data => :post,
-                                            :suspect_records => :get},
+                                            :export_data => :post},
                 :member => {:export_photo_to_pdf => :get} do |child|
     child.resource :history, :only => :show
     child.resources :attachments, :only => :show    


### PR DESCRIPTION
Remove Suspect Records Page and Redirect Homepage Link to Filtered Child Records 

This pull request removes the /children/suspect_records route and instead points the home flagged link to /filter/flagged.
