### PR TITLE
MT - Story #548 - Fixed issue on new user creation whereby the password ...

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -59,7 +59,7 @@ class User < CouchRestRails::Document
                       :message =>"Please enter a valid email address"
 
 
-  validates_confirmation_of :password, :if => :password_required?
+  validates_confirmation_of :password, :if => :password_required? && :password_confirmation_entered?
   validates_with_method   :user_name, :method => :is_user_name_unique
 
 
@@ -143,6 +143,10 @@ class User < CouchRestRails::Document
 
   def password_required?
     crypted_password.blank? || !password.blank? || !password_confirmation.blank?
+  end
+
+  def password_confirmation_entered?
+    !password_confirmation.blank?
   end
 
   def make_user_name_lowercase

--- a/features/edit_user_details.feature
+++ b/features/edit_user_details.feature
@@ -111,4 +111,5 @@ Scenario: Password field should not be blank if re-enter password field is fille
   When I am on the edit user page for "johndoe1"
   Then I fill in "pass" for "password"
   And I press "Update"
-  Then I should see "Password does not match the confirmation"
+  Then I should see "Please enter password confirmation"
+  And I should not see "Password does not match the confirmation"


### PR DESCRIPTION
...field was being flagged as not matching the password confirmation field when no password confirmation had been entered.
