### PR TITLE
Add Vagrantfile to streamline VM-setup.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,9 @@
+# This file is for running the RapidFTR Rails development virtual machine.
+# For instructions, see
+# https://github.com/jorgej/RapidFTR/wiki/Using-a-VM-for-development
+# For documentation on this file format, see
+# http://vagrantup.com/docs/vagrantfile.html
+Vagrant::Config.run do |config|
+  config.vm.box = "rapid_ftr_rails"
+  config.vm.box_url = "https://s3.amazonaws.com/RapidFTR-dist/rails_developer_20120228.box"
+end


### PR DESCRIPTION
Can someone test this out?
- Get this branch onto your local (the "host machine").
  - `git checkout -b duelinmarkers-add_Vagrantfile master`
  - `git pull https://duelinmarkers@github.com/duelinmarkers/RapidFTR.git add_Vagrantfile`
- Install vagrant, but stop before "Your First Vagrant Virtual Environment" (http://vagrantup.com/docs/getting-started/index.html).
- From the root of the repo (where I added the `Vagrantfile`) run `vagrant up`. It should download and boot the box. (Beware: the download is about 700MB.)
- `vagrant ssh` into the VM (the "guest machine").
- `cd /vagrant` to find the guest machine's (shared directory) view of the host machine directory you were just in.
- `bundle install` to install gems. (You may have to `sudo bundle install`, but try w/o sudo first.)
- `rake couchdb:create` and look for output that indicates healthy creation of CouchDB databases.

If you got this far, then the Vagrantfile worked! Please let me know. If you want to keep going, follow the last few instructions here: https://github.com/jorgej/RapidFTR/wiki/Using-a-VM-for-development. Once this is merged I'll update those instructions for this slightly easier process.
