### PR TITLE
#1171 fix: make sure name filed keep on the first row

### DIFF
--- a/capybara_features/edit_form_section.feature
+++ b/capybara_features/edit_form_section.feature
@@ -5,6 +5,14 @@ Feature: So that admin can customize form section details
       | name | unique_id | editable | order | enabled | perm_enabled |
       | Basic details | basic_details | true | 1 | true | true |
       | Family details | family_details | true | 2 | true | false |
+    And the following fields exists on "basic_details":
+    	| name | type | display_name | editable |
+    	| name | text_field | Name | false |
+      | nick_name | text_field | Nick Name | true |
+      | second_name | text_field | Second Name | true |
+    And the following fields exists on "family_details":
+    	| name | type | display_name |
+    	| another_field | text_field | another field |
 
   Scenario: Admins should be able to edit name and description
     Given I am logged in as an admin
@@ -38,4 +46,15 @@ Feature: So that admin can customize form section details
     Given I am logged in as an admin
     And I am on the edit form section page for "family_details"
     Then I should see "Visible checkbox" with id "form_section_enabled"
+
+  @javascript
+  Scenario: Admins should not be able to demote the name field by promoting following field
+    Given I am logged in as an admin
+    And I am on the form section page
+    And I follow "Basic details"
+    And I should be able to demote the field "nick_name"
+    And I should not be able to promote the field "nick_name"
+    When I demote field "nick_name"
+    Then I should not be able to promote the field "second_name"
+    And I should be able to promote the field "nick_name"
 

--- a/capybara_features/step_definitions/form_section_steps.rb
+++ b/capybara_features/step_definitions/form_section_steps.rb
@@ -45,6 +45,26 @@ Then /^the form section "([^"]*)" should not be selected to toggle visibility$/ 
   find_field(form_section_visibility_checkbox_id(form_section)).should_not be_checked
 end
 
+Then /^I should not be able to promote the field "([^"]*)"$/ do |field|
+  page.should have_selector("//a[@id='#{field}_up' and @style='display: none;']") 
+end
+
+Then /^I should not be able to demote the field "([^"]*)"$/ do |field|
+   page.should have_selector("//a[@id='#{field}_down' and @style='display: none;']") 
+end
+
+Then /^I should be able to demote the field "([^"]*)"$/ do |field|
+  page.should have_selector("//a[@id='#{field}_down' and @style='display: inline;']")
+end
+
+When /^I demote field "([^"]*)"$/ do |field|
+  find(:css, "a##{field}_down").click
+end
+
+Then /^I should be able to promote the field "([^"]*)"$/ do |field|
+ page.should have_selector("//a[@id='#{field}_up' and @style='display: inline;']")
+end
+
 
 def row_for(section_name)
   page.find row_xpath_for(section_name)

--- a/public/javascripts/form_section.js
+++ b/public/javascripts/form_section.js
@@ -10,6 +10,10 @@ function onFormSectionDetailsEditPage() {
     return $('#editFormDetails').length === 1;
 }
 
+function nameIsTheFirstRow(){
+  return $("#nameRow").index() == 0;
+}
+
 function initOrderingColumns() {
     var mainContainer = "form_sections";
 
@@ -19,7 +23,7 @@ function initOrderingColumns() {
     });
     
     var fieldToStartFrom = 1;
-    if (onFormSectionDetailsEditPage()){
+    if (onFormSectionDetailsEditPage() && !nameIsTheFirstRow()){
 	fieldToStartFrom = 0;
     }
     $("#"+mainContainer+" tbody tr:eq("+fieldToStartFrom+")").each(function(index, element){


### PR DESCRIPTION
To fix 1171, change the form_section.js. When name field exists, keep fieldToStartFrom=1 even though it is on details edit page. 
