### PR TITLE
Don't create unique id if it already exists

### DIFF
--- a/app/models/child.rb
+++ b/app/models/child.rb
@@ -219,9 +219,11 @@ view_by :duplicates_of,
   end
 
   def create_unique_id(user_name)
-    unknown_location = 'xxx'
-    truncated_location = self['last_known_location'].blank? ? unknown_location : self['last_known_location'].slice(0, 3).downcase
-    self['unique_identifier'] = user_name + truncated_location + UUIDTools::UUID.random_create.to_s.slice(0, 5)
+    unless self['unique_identifier']
+      unknown_location = 'xxx'
+      truncated_location = self['last_known_location'].blank? ? unknown_location : self['last_known_location'].slice(0, 3).downcase
+      self['unique_identifier'] = user_name + truncated_location + UUIDTools::UUID.random_create.to_s.slice(0, 5)
+    end
   end
 
   def set_creation_fields_for(user_name)


### PR DESCRIPTION
Going forward BB app would be creating a unique id when ever the child is created. so we need not recreate the id in the rails app
