### PR TITLE
#[1612] Alabê - Change url button to children_path to fix it

### DIFF
--- a/app/views/duplicates/new.html.erb
+++ b/app/views/duplicates/new.html.erb
@@ -12,7 +12,7 @@
 
       <br /><br />
       <div class="btn_panel">
-        <%= link_to t("child.actions.cancel"), :back %>
+        <%= link_to t("child.actions.cancel"), children_path %>
         <%= submit_tag(t("child.mark_as_duplicate"), :confirm => t("child.messages.confirm_duplicate")) %>
       </div>
     <% end %>


### PR DESCRIPTION
Change url button to children_path to fix the redirect error after trying cancel duplication
