### PR TITLE
Pin Ruby version to make it obvious when someone has the wrong version.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+ruby '1.8.7'
+
 gem 'couchrest',      '0.34'
 gem 'fastercsv',      '1.5.3'
 gem 'json',           '1.4.6'


### PR DESCRIPTION
The errors that arise when the wrong Ruby version is used are subtle. For me, using Ruby 1.9 meant that trying to seed the CouchDB crashed on some Arabic translation.

Especially if we're moving Ruby versions, we should make it explicit which one we're expecting.
