### PR TITLE
fix bug 1822

### DIFF
--- a/app/views/users/_editable_user.html.erb
+++ b/app/views/users/_editable_user.html.erb
@@ -49,12 +49,12 @@
 
     <p>
       <%= f.label :password, t('login.password.label'), :class=>'key'  %>
-      <%= f.password_field :password, :autocomplete => "off" %>
+      <%= f.password_field :password, :autocomplete => "off" %>*
     </p>
 
     <p>
       <%= f.label :password_confirmation,t("login.password.re_enter"), :class=>'key'  %>
-      <%= f.password_field :password_confirmation, :autocomplete => "off" %>
+      <%= f.password_field :password_confirmation, :autocomplete => "off" %>*
     </p>
 
     <% if !trying_to_edit_ourself %>


### PR DESCRIPTION
While creating a user the 'password' and 're-enter password' field should have an asterix (*)
