### PR TITLE
Child's Wishes needs an apostrophe.

### DIFF
--- a/lib/rapid_ftr/form_section_setup.rb
+++ b/lib/rapid_ftr/form_section_setup.rb
@@ -437,7 +437,7 @@ module RapidFTR
         ]
         FormSection.create!({"visible"=>true,:order=> 6,
                              :unique_id=>"childs_wishes", :fields => child_wishes_fields,
-                            "name_all" => "Childs Wishes",
+                            "name_all" => "Child's Wishes",
                             "description_all" => ""
                             })
 


### PR DESCRIPTION
"Child's" is possessive, so it needs an apostrophe.

One thing I'm not sure about - I noticed that the misspelt version is in the database too, for the name_xx attributes of a FormSection document. Will fixing the spelling in code cause any problems for this?
