### PR TITLE
Unauthorized side tabs removed from view

### DIFF
--- a/app/views/shared/_side_tab.html.erb
+++ b/app/views/shared/_side_tab.html.erb
@@ -1,7 +1,9 @@
  <div class="side-tab">
     <ul>
-      <li class=<%= (highlight_page == 'users' ? 'current' : '') %>><%= link_to I18n.t("users.label"), users_path %></li>
-      <li class=<%= (highlight_page == 'unverified' ? 'current' : '') %>><%= link_to I18n.t("users.unverified"), unverified_users_path %></li>
-      <li class=<%= (highlight_page == 'roles' ? 'current' : '') %>><%= link_to t("roles.label"), roles_path %></li>
+      <li class=<%= (highlight_page == 'users' ? 'current' : '') %>><%= link_to I18n.t("users.label"), users_path if can?(:read, User)%></li>
+      <li class=<%= (highlight_page == 'unverified' ? 'current' : '') %>>
+      	<%= link_to I18n.t("users.unverified"), unverified_users_path if can?(:show, User)  %></li>
+      <li class=<%= (highlight_page == 'roles' ? 'current' : '') %>>
+      	<%= link_to t("roles.label"), roles_path if can?(:index, Role) %></li>
     </ul>
  </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,6 +1,6 @@
 <h1 class="no_border"><%= t("users.label") %></h1>
 <div class="page-content-new">
-  <%= render :partial => 'shared/side_tab', :locals => {:highlight_page => 'users'} %>
+  <%= render :partial => 'shared/side_tab', :locals => {:highlight_page => ''} %>
   <div class="side-tab-content">
     <h2 class="float_left no_border"><%= link_to I18n.t("users.label"), users_path %> &gt; <%= @user.user_name %>
       <% if can? :edit, User %>

--- a/public/stylesheets/new_core.css
+++ b/public/stylesheets/new_core.css
@@ -402,7 +402,7 @@ body {
                 position: relative;
                 left: 9px;
                 font-size: 1.1em;
-                color: #aaa; }
+                color: #000; }
                 body .page_container .page-content .page-content-new .side-tab ul li a:hover {
                   color: #666; }
             body .page_container .page-content .page-content-new .side-tab ul li.current a {


### PR DESCRIPTION
In the 'my account' page, the side tabs Users, Roles, Unverified Users are now shown only if the current user is privileged to do so. Otherwise it is hidden.
