### PR TITLE
Added rails-dev-tweaks gem to increase development speed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,7 @@ group :development, :assets, :cucumber do
   gem 'compass-rails', '~> 1.0.3'
   gem 'coffee-rails',  '~> 3.2.1'
   gem 'uglifier',      '~> 2.0.1'
+  gem 'rails-dev-tweaks', '~> 1.1'
 end
 
 group :test, :cucumber do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -184,6 +184,9 @@ GEM
       activesupport (= 3.2.16)
       bundler (~> 1.0)
       railties (= 3.2.16)
+    rails-dev-tweaks (1.1.0)
+      actionpack (>= 3.1)
+      railties (>= 3.1)
     railties (3.2.16)
       actionpack (= 3.2.16)
       activesupport (= 3.2.16)
@@ -291,6 +294,7 @@ DEPENDENCIES
   pdf-reader (= 0.8.6)
   prawn (= 0.8.4)
   rails (= 3.2.16)
+  rails-dev-tweaks (~> 1.1)
   rake (= 0.9.3)
   rapidftr_addon!
   rapidftr_addon_cpims!


### PR DESCRIPTION
Rails Asset Pipeline has a known quirk. It will reload the entire Rails code whenever an Asset is requested. This gem reduces that and greatly increases development speed.
