### PR TITLE
Add backward compatibility for downloading form sections to 1.2.x apks

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -106,6 +106,9 @@ RapidFTR::Application.routes.draw do
 
   end
 
+  # Backwards compatibility with 1.2
+  match '/published_form_sections', :to => 'api/form_sections#index', :via => [:post, :get, :put, :delete]
+
 #######################
 # FORM SECTION URLS
 #######################

--- a/spec/routing/formsection_routing_spec.rb
+++ b/spec/routing/formsection_routing_spec.rb
@@ -30,4 +30,9 @@ describe 'Form Section routing', :type => :routing do
   it "has route for update field page" do
     expect({:put => '/form_section/form_section_unique_id/fields/field_id'}).to route_to(:controller => 'fields', :action => "update", "form_section_id"=>"form_section_unique_id", "id"=>"field_id")
   end
+
+  it "redirects /published_form_sections to the new API controller" do
+    expect({ :get => '/published_form_sections' }).to route_to(:controller => 'api/form_sections', :action => 'index')
+    expect({ :get => '/published_form_sections.json' }).to route_to(:controller => 'api/form_sections', :action => 'index', :format => 'json')
+  end
 end


### PR DESCRIPTION
references rapidftr/tracker#45
