### PR TITLE
Use human readable field names in the change log records

### DIFF
--- a/app/helpers/histories_helper.rb
+++ b/app/helpers/histories_helper.rb
@@ -1,6 +1,8 @@
 module HistoriesHelper
 
   def history_entry_for history, field, change
+    @form_sections = FormSection.all
+
     if field == "photo_keys"
       return {:partial => "shared/histories/photo_history_change",
               :locals =>{
@@ -33,11 +35,20 @@ module HistoriesHelper
       # do nothing, because we are already displaying the duplicate_of as a part of duplicate change
     else
       return {:partial => "shared/histories/history_change",
-              :locals => default_locals_for(history, change).merge(:field => field.humanize)}
+              :locals => default_locals_for(history, change).merge(:field => get_field_display_name(field))}
     end
   end
 
   private
+
+  def get_field_display_name field_name
+    @form_sections.each do |form_section|
+      field = form_section.get_field_by_name(field_name)
+      return field.display_name.humanize unless field.nil?
+    end
+
+    field_name.humanize
+  end
 
   def default_locals_for history, change
     {

--- a/app/models/form_section.rb
+++ b/app/models/form_section.rb
@@ -200,6 +200,10 @@ class FormSection < CouchRest::Model::Base
     self.save
   end
 
+  def get_field_by_name field_name
+    self.fields.select { |field| field.name == field_name }.first
+  end
+
   protected
 
   def validate_name_format

--- a/capybara_features/view_child_record_log.feature
+++ b/capybara_features/view_child_record_log.feature
@@ -47,7 +47,7 @@ Feature:
     #When I follow photo with timestamp "2010-03-01T175933"
     #Then I should see the photo corresponding to "capybara_features/resources/jeff.png"
 
-  @no_expire
+  @no_expire @javascript
   Scenario:  I log in as a different user, edit and view the record log
 
     Given the date/time is "July 19 2010 13:05:15 UTC"
@@ -72,9 +72,9 @@ Feature:
 
     Then I should see "2010-10-29 14:12:15 UTC Birthplace changed from Haiti to Zambia by bobby"
     And I should see "2010-10-29 14:12:15 UTC Nationality initially set to Bombay by bobby"
-    And I should see "2010-10-29 14:12:15 UTC Date of birth changed from 12/12/2000 to 12/12/1999 by bobby"
+    And I should see "2010-10-29 14:12:15 UTC Date of birth (dd/mm/yyyy) changed from 12/12/2000 to 12/12/1999 by bobby"
     And I should see "2010-10-29 14:12:15 UTC Name changed from Jorge Just to George Harrison by bobby"
-    And I should see "2010-10-29 14:12:15 UTC Gender changed from Male to Female by bobby"
+    And I should see "2010-10-29 14:12:15 UTC Sex changed from Male to Female by bobby"
     # Order tested at the moment in the show.html.erb_spec.rb view test for histories
 
   Scenario: Clicking back from the change log

--- a/spec/models/field_spec.rb
+++ b/spec/models/field_spec.rb
@@ -291,4 +291,7 @@ describe "Child record field view model", :type => :model do
     form = FormSection.create :name => 'test_form2', :unique_id => 'test_form', :fields => [field]
     expect(field.errors[:name]).to eq(["Field already exists on form 'test_form1'"])
   end
+
+
+
 end

--- a/spec/models/form_section_spec.rb
+++ b/spec/models/form_section_spec.rb
@@ -416,4 +416,24 @@ describe FormSection, :type => :model do
       end
     end
   end
+
+  describe "#field_by_id" do
+
+    it 'should find field by id' do
+      expected_field = Field.new(:name => "a_field", :type => "text_field", :display_name => "A Field")
+      form_section = FormSection.new :name => 'form_section', :unique_id => "unique_id", :fields => [expected_field]
+      form_section.save!
+
+      retrieved_field = form_section.get_field_by_name("a_field")
+      expect(expected_field).to eq(retrieved_field)
+    end
+
+    it 'should return nothing when field name does not match' do
+      form_section = FormSection.new :name => 'new_form_section', :unique_id => "new_unique_id"
+      form_section.save!
+
+      expected_field = form_section.get_field_by_name("some_other_field")
+      expect(expected_field).to eq(nil)
+    end
+  end
 end


### PR DESCRIPTION
@austiine04 @ctumwebaze  fix rapidftr/tracker#133 makes change logs display field names instead of ids for newly created fields
