### PR TITLE
Update environment config, considerably speed up development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -21,5 +21,5 @@ RapidFTR::Application.configure do
   # This option may cause significant delays in view rendering with a large
   # number of complex assets.
   config.assets.compress = false
-  config.assets.debug = true
+  config.assets.debug = false
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -22,21 +22,12 @@ RapidFTR::Application.configure do
   # Disable Rails's static asset server (Apache or nginx will already do this).
   config.serve_static_assets = false
 
-  config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect'
-
-  # Compress JavaScripts and CSS.
-  config.assets.js_compressor = :uglifier
-  # config.assets.css_compressor = :sass
-
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
 
   # Generate digests for assets URLs.
   config.assets.digest = true
   config.assets.compress = true
-
-  # Version of your assets, change this if you want to expire all your assets.
-  config.assets.version = '1.0'
 
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = "X-Sendfile" # for apache
@@ -65,10 +56,6 @@ RapidFTR::Application.configure do
   # config.assets.precompile += %w( search.js )
 
   config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect'
-
-  # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
-  # the I18n.default_locale when a translation can not be found).
-  config.i18n.fallbacks = true
 
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -15,7 +15,6 @@ RapidFTR::Application.configure do
 
   # Configure static asset server for tests with Cache-Control for performance.
   config.serve_static_assets  = false
-  config.static_cache_control = "public, max-age=3600"
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true


### PR DESCRIPTION
Disabling `assets.debug` considerably increases development speed. Enable that temporarily if you want to do some asset debugging.
