### PR TITLE
fixes backward compatibility for form sections

### DIFF
--- a/app/controllers/api/form_sections_controller.rb
+++ b/app/controllers/api/form_sections_controller.rb
@@ -13,6 +13,7 @@ class Api::FormSectionsController < Api::ApiController
 
   def children
     form_sections = FormSection.enabled_by_order_for_form(Child::FORM_NAME)
-    render json: form_sections
+    render json: form_sections.map(&:formatted_hash)
   end
 end
+

--- a/spec/controllers/api/form_sections_controller_spec.rb
+++ b/spec/controllers/api/form_sections_controller_spec.rb
@@ -47,8 +47,8 @@ describe Api::FormSectionsController, :type => :controller do
     end
 
     it "should return by order" do
-      expect(@json[0]["name_en"]).to eq(@form_section3.name_en)
-      expect(@json[1]["name_en"]).to eq(@form_section1.name_en)
+      expect(@json[0]["name"]["en"]).to eq(@form_section3.name_en)
+      expect(@json[1]["name"]["en"]).to eq(@form_section1.name_en)
     end
   end
 end


### PR DESCRIPTION
@ctumwebaze rapidftr/tracker#53 
This fix supports the backward compatibility of the 1.2.1 apk. The compatibility was broken due to missing call to formatted_hash to format the localized properties of the form section i.e display name.
