### PR TITLE
processing enquiries on the server

### DIFF
--- a/app/controllers/api/enquiries_controller.rb
+++ b/app/controllers/api/enquiries_controller.rb
@@ -29,7 +29,7 @@ class Api::EnquiriesController < Api::ApiController
 
     @enquiry.update_from(enquiry_json)
 
-    unless @enquiry.valid? && !enquiry_json['criteria'].nil? && !enquiry_json['criteria'].empty?
+    unless @enquiry.valid? && !@enquiry['criteria'].nil? && !@enquiry['criteria'].empty?
       render :json => {:error => @enquiry.errors.full_messages}, :status => 422
       return
     end
@@ -81,9 +81,6 @@ class Api::EnquiriesController < Api::ApiController
       enquiry = JSON.parse(params['enquiry'])
     else
       enquiry = params['enquiry']
-      if enquiry['criteria'].is_a?(String)
-         enquiry['criteria']=JSON.parse(enquiry['criteria'])
-      end
     end
     enquiry
   end

--- a/capybara_features/api/enquiries/create_or_edit_enquiry.feature
+++ b/capybara_features/api/enquiries/create_or_edit_enquiry.feature
@@ -1,10 +1,24 @@
 Feature: Creating an enquiry using the API
 
   Background:
+
     Given devices exist
       | imei  | blacklisted | user_name |
       | 10001 | false       | tim       |
       | 10002 | false       | jim       |
+    And the following forms exist in the system:
+      | name         |
+      | Enquiries    |
+    And the following form sections exist in the system on the "Enquiries" form:
+      | name           | unique_id      | editable | order | visible | perm_enabled |
+      | Basic details  | basic_details  | false    | 1     | true    | true         |
+    And the following fields exists on "basic_details":
+      | name           | type       | display_name | editable |
+      | name           | text_field | Name         | false    |
+      | location       | text_field | Location     | true     |
+      | enquirer_name  | text_field | Enquirer Name  | true     |
+      | characteristic | text_field | Characteristic  | true     |
+      | nationality    | text_field | Nationality  | true     |
     Given a registration worker "tim" with a password "123"
     And I login as tim with password 123 and imei 10001
 
@@ -16,10 +30,8 @@ Feature: Creating an enquiry using the API
       {
         "enquiry": {
           "enquirer_name" : "bob",
-          "criteria" : {
-            "name" : "Batman",
-            "location" : "Kampala"
-          }
+          "name" : "Batman",
+          "location" : "Kampala"
         }
       }
       """
@@ -37,9 +49,7 @@ Feature: Creating an enquiry using the API
     """
       {
         "enquiry": {
-          "enquirer_name" : "bob",
-          "criteria" : {
-          }
+          "parent_name" : "bob"
         }
       }
     """
@@ -56,9 +66,7 @@ Feature: Creating an enquiry using the API
       {
         "enquiry": {
           "enquirer_name" : "bobby",
-          "criteria" : {
-            "name" : "Batman"
-          }
+          "name" : "Batman"
         }
       }
       """
@@ -71,9 +79,7 @@ Feature: Creating an enquiry using the API
       {
         "enquiry": {
           "enquirer_name" : "Bob the builder",
-          "criteria" : {
-            "name" : "Batman"
-          }
+          "name" : "Batman"
         }
       }
       """

--- a/capybara_features/api/enquiries/sync_enquiries.feature
+++ b/capybara_features/api/enquiries/sync_enquiries.feature
@@ -4,6 +4,19 @@ Feature: Sync one/all enquiries on the API
     Given devices exist
       | imei  | blacklisted | user_name |
       | 10001 | false       | tim       |
+    And the following forms exist in the system:
+      | name         |
+      | Enquiries    |
+    And the following form sections exist in the system on the "Enquiries" form:
+      | name           | unique_id      | editable | order | visible | perm_enabled |
+      | Basic details  | basic_details  | false    | 1     | true    | true         |
+    And the following fields exists on "basic_details":
+      | name           | type       | display_name | editable |
+      | name           | text_field | Name         | false    |
+      | location       | text_field | Location     | true     |
+      | enquirer_name  | text_field | Enquirer Name  | true     |
+      | characteristic | text_field | Characteristic  | true     |
+      | nationality    | text_field | Nationality  | true     |
     Given a registration worker "tim" with a password "123"
     And I login as tim with password 123 and imei 10001
 

--- a/capybara_features/api/enquiries/trigger_matches_on_enquiry.feature
+++ b/capybara_features/api/enquiries/trigger_matches_on_enquiry.feature
@@ -5,6 +5,19 @@ Feature: Check for matches after creating/editing an enquiry on the API
       | imei  | blacklisted | user_name |
       | 10001 | false       | tim       |
       | 10002 | false       | jim       |
+    And the following forms exist in the system:
+      | name         |
+      | Enquiries    |
+    And the following form sections exist in the system on the "Enquiries" form:
+      | name           | unique_id      | editable | order | visible | perm_enabled |
+      | Basic details  | basic_details  | false    | 1     | true    | true         |
+    And the following fields exists on "basic_details":
+      | name           | type       | display_name | editable |
+      | name           | text_field | Name         | false    |
+      | location       | text_field | Location     | true     |
+      | enquirer_name  | text_field | Enquirer Name  | true     |
+      | characteristic | text_field | Characteristic  | true     |
+      | nationality    | text_field | Nationality  | true     |
     Given a registration worker "tim" with a password "123"
     And I login as tim with password 123 and imei 10001
 
@@ -19,9 +32,7 @@ Feature: Check for matches after creating/editing an enquiry on the API
       {
         "enquiry": {
           "enquirer_name" : "bob",
-          "criteria" : {
-             "name" :  "Tom"
-          }
+          "name" :  "Tom"
         }
       }
     """
@@ -44,9 +55,7 @@ Feature: Check for matches after creating/editing an enquiry on the API
       {
         "enquiry": {
           "enquirer_name" : "bob",
-          "criteria" : {
-            "name" : "Tom"
-          }
+          "name" : "Tom"
         }
       }
       """
@@ -56,10 +65,8 @@ Feature: Check for matches after creating/editing an enquiry on the API
       {
         "enquiry": {
           "enquirer_name" : "bob",
-          "criteria" : {
-            "name" : "Tom",
-            "location" : "kampala"
-          }
+          "name" : "Tom",
+          "location" : "kampala"
         }
       }
       """

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -571,6 +571,7 @@ en:
         presence_of_enquirer_name: "Please add enquirer name to your enquiry"
         presence_of_reporter_details: "Please add reporter details to your enquiry"
         create_forbidden: "Forbidden"
+        at_least_one_field: "Please fill in at lease one field or upload a file"
         not_found: "Not found"
         malformed_query: "Invalid request"
 

--- a/spec/integration/match_service_spec.rb
+++ b/spec/integration/match_service_spec.rb
@@ -4,13 +4,16 @@ describe MatchService, type: :request, solr: true do
 
   before :each do
     reset_couchdb!
+
+    form = create :form, name: Enquiry::FORM_NAME
+
     create :form_section, name: 'test_form', fields: [
-      build(:text_field, name: 'name'),
-      build(:text_field, name: 'nationality'),
-      build(:text_field, name: 'country'),
-      build(:text_field, name: 'birthplace'),
-      build(:text_field, name: 'languages')
-    ]
+        build(:text_field, name: 'name'),
+        build(:text_field, name: 'nationality'),
+        build(:text_field, name: 'country'),
+        build(:text_field, name: 'birthplace'),
+        build(:text_field, name: 'languages')
+    ], form: form
   end
 
   before :each do
@@ -19,27 +22,26 @@ describe MatchService, type: :request, solr: true do
 
   it "should match children from a country given enquiry criteria with key different from child's country key " do
     Sunspot.setup(Child) do
-        text :location
-        text :nationality
-        text :country
+      text :location
+      text :nationality
+      text :country
     end
-    Child.create!(:name => "christine", :created_by => "me", :country => "uganda", :created_organisation => "stc")
-    Child.create!(:name => "john", :created_by => "not me", :nationality => "uganda", :created_organisation => "stc")
-    enquiry = Enquiry.create!(:enquirer_name => "Foo Bar", :reporter_details => {:gender => "male"}, :criteria => {:location => "uganda"})
+    child1 = Child.create!(:name => "christine", :created_by => "me", :country => "uganda", :created_organisation => "stc")
+    child2 = Child.create!(:name => "john", :created_by => "not me", :nationality => "uganda", :created_organisation => "stc")
+    enquiry = Enquiry.create!(:name => "Foo Bar", :gender => "male", :nationality => "uganda")
 
     children = MatchService.search_for_matching_children(enquiry["criteria"])
 
     expect(children.size).to eq(2)
-    expect(children.first.name).to eq("christine")
-    expect(children.last.name).to eq("john")
+    expect(children).to include(*[child1, child2])
   end
 
   it "should match records when criteria has a space" do
     Sunspot.setup(Child) do
-        text :country
+      text :country
     end
     Child.create!(:name => "Christine", :created_by => "me", :country => "Republic of Uganda", :created_organisation => "stc")
-    enquiry = Enquiry.create!(:enquirer_name => "Foo Bar", :reporter_details => {:gender => "male"}, :criteria => {:location => "uganda"})
+    enquiry = Enquiry.create!(:enquirer_name => "Foo Bar", :gender => "male", :country => "uganda")
 
     children = MatchService.search_for_matching_children(enquiry["criteria"])
 
@@ -49,14 +51,14 @@ describe MatchService, type: :request, solr: true do
 
   it "should match multiple records given multiple criteria" do
     Sunspot.setup(Child) do
-        text :location
-        text :birthplace
-        text :languages
+      text :location
+      text :birthplace
+      text :languages
     end
     Child.create!(:name => "Christine", :created_by => "me", :country => "Republic of Uganda", :created_organisation => "stc")
     Child.create!(:name => "Man", :created_by => "me", :nationality => "Uganda", :gender => "Male", :created_organisation => "stc")
     Child.create!(:name => "dude", :created_by => "me", :birthplace => "Dodoma", :languages => "Swahili", :created_organisation => "stc")
-    enquiry = Enquiry.create!(:enquirer_name => "Foo Bar", :reporter_details => {:gender => "male"}, :criteria => {:location => "uganda", :birthplace=>"dodoma", :languages => "Swahili"})
+    enquiry = Enquiry.create!(:enquirer_name => "Foo Bar", :gender => "male", :country => "uganda", :birthplace => "dodoma", :languages => "Swahili")
 
     children = MatchService.search_for_matching_children(enquiry["criteria"])
 

--- a/spec/integration/solar_spec.rb
+++ b/spec/integration/solar_spec.rb
@@ -14,7 +14,7 @@ describe "Solar", type: :request, solr: true do
     Sunspot.remove_all(Child)
 
     create :form_section, fields: [
-      build(:text_field, name: 'name')
+        build(:text_field, name: 'name')
     ]
 
     @child1 = create(:child, 'last_known_location' => "New York", "name" => "Mohammed Smith")
@@ -49,16 +49,19 @@ describe "Enquiry Mapping", type: :request, solr: true do
 
   before :all do
     Sunspot.remove_all(Child)
+    reset_couchdb!
+
+    form = create :form, name: Enquiry::FORM_NAME
 
     create :form_section, fields: [
-      build(:text_field, name: 'name')
-    ]
+        build(:text_field, name: 'name')
+    ], form: form
 
     @child1 = create(:child, 'last_known_location' => "New York", "name" => "Mohammed Smith")
     @child2 = create(:child, 'last_known_location' => "New York", "name" => "Muhammed Jones")
     @child3 = create(:child, 'last_known_location' => "New York", "name" => "Muhammad Brown")
     @child4 = create(:child, 'last_known_location' => "New York", "name" => "Ammad Brown")
-    @enquiry = Enquiry.create("enquirer_name" => "Kavitha", "criteria" => {"name" => "Ammad"}, "reporter_details" => {"location" => "Kyangwali"})
+    @enquiry = Enquiry.create("enquirer_name" => "Kavitha", "name" => "Ammad", "location" => "Kyangwali")
   end
 
   def match(criteria)

--- a/spec/models/enquiry_spec.rb
+++ b/spec/models/enquiry_spec.rb
@@ -20,16 +20,11 @@ describe Enquiry, :type => :model do
       expect(enquiry.errors[:criteria]).to eq(["Please add criteria to your enquiry"])
     end
 
-    it "should not create enquiry without enquirer_name" do
-      enquiry = create_enquiry_with_created_by('user name', {:criteria => {:name => 'Child name'}})
+    it "should fail to validate if all fields are nil" do
+      enquiry = Enquiry.new()
+      allow(FormSection).to receive(:all_visible_child_fields_for_form).and_return [Field.new(:type => 'numeric_field', :name => 'height', :display_name => "height")]
       expect(enquiry).not_to be_valid
-      expect(enquiry.errors[:enquirer_name]).to eq(["Please add enquirer name to your enquiry"])
-    end
-
-    it "should not create enquiry with empty enquirer name" do
-      enquiry = create_enquiry_with_created_by('user name', {:criteria => {:name => ''}})
-      expect(enquiry).not_to be_valid
-      expect(enquiry.errors[:enquirer_name]).to eq(["Please add enquirer name to your enquiry"])
+      expect(enquiry.errors[:validate_has_at_least_one_field_value]).to eq(["Please fill in at lease one field or upload a file"])
     end
 
     describe '#update_from_properties' do
@@ -72,15 +67,18 @@ describe Enquiry, :type => :model do
       before :each do
         reset_couchdb!
         Sunspot.setup(Child) do
-            text :location
-            text :name
-            text :gender
+          text :location
+          text :name
+          text :gender
         end
+        form = create :form, name: Enquiry::FORM_NAME
+
         create :form_section, name: 'test_form', fields: [
             build(:text_field, name: 'name'),
             build(:text_field, name: 'location'),
-            build(:text_field, name: 'gender')
-        ]
+            build(:text_field, name: 'gender'),
+            build(:text_field, name: 'enquirer_name')
+        ], form: form
       end
 
       it "should be an empty array when enquiry is created" do
@@ -89,16 +87,17 @@ describe Enquiry, :type => :model do
       end
 
       it "should contain potential matches given one matching child" do
+        enquiry = Enquiry.new()
         child = Child.create(:name => "eduardo aquiles", 'created_by' => "me", 'created_organisation' => "stc")
-        enquiry = Enquiry.create!(:criteria => {"name " => "eduardo"}, :enquirer_name => "Kisitu")
+        enquiry = Enquiry.create!(:enquirer_name => "Kisitu", :name => "eduardo")
 
+        expect(enquiry.criteria).not_to be_empty
         expect(enquiry.potential_matches).not_to be_empty
         expect(enquiry.potential_matches).to eq([child.id])
       end
 
       it "should not fail when enquiry has no potential matches" do
-        enquiry = Enquiry.create!(:criteria => {:name => "does not exist"}, :enquirer_name => "Kisitu")
-
+        enquiry = Enquiry.create!(:name => "does not exist", :enquirer_name => "Kisitu")
         expect(enquiry.potential_matches).to be_empty
       end
 
@@ -107,7 +106,7 @@ describe Enquiry, :type => :model do
         child2 = Child.create(:name => "john doe", 'created_by' => "me", :location => "kampala", 'created_organisation' => "stc")
         child3 = Child.create(:name => "foo bar", 'created_by' => "me", :gender => "male", 'created_organisation' => "stc")
 
-        enquiry = Enquiry.create!(:criteria => {:name => "eduardo", :location => "kampala", :gender => "male"}, :enquirer_name => "Kisitu")
+        enquiry = Enquiry.create!(:name => "eduardo", :location => "kampala", :gender => "male", :enquirer_name => "Kisitu")
 
         expect(enquiry.potential_matches.size).to eq(3)
         expect(enquiry.potential_matches).to include(child1.id, child2.id, child3.id)
@@ -115,12 +114,12 @@ describe Enquiry, :type => :model do
 
       it "should assure that potential_matches contains no duplicates" do
         child1 = Child.create(:name => "eduardo aquiles", :gender => "male", 'created_by' => "me", 'created_organisation' => "stc")
-        enquiry = Enquiry.create!(:criteria => {"name" => "eduardo"}, :enquirer_name => "Kisitu")
+        enquiry = Enquiry.create!(:enquirer_name => "Kisitu", :name => "eduardo")
 
         expect(enquiry.potential_matches.size).to eq(1)
         expect(enquiry.potential_matches).to eq([child1.id])
 
-        enquiry[:criteria].merge!({"gender" => "male"})
+        enquiry.gender = "male"
         enquiry.save!
 
         expect(enquiry.potential_matches.size).to eq(1)
@@ -132,12 +131,12 @@ describe Enquiry, :type => :model do
         child2 = Child.create(:name => "john doe", 'created_by' => "me", :location => "kampala", 'created_organisation' => "stc")
         child3 = Child.create(:name => "foo bar", 'created_by' => "me", :gender => "male", 'created_organisation' => "stc")
 
-        enquiry = Enquiry.create!(:criteria => {"name" => "eduardo", "location" => "kampala"}, :enquirer_name => "Kisitu")
+        enquiry = Enquiry.create!(:name => "eduardo", :location => "kampala", :enquirer_name => "Kisitu")
 
         expect(enquiry.potential_matches.size).to eq(2)
         expect(enquiry.potential_matches).to include(child1.id, child2.id)
 
-        enquiry[:criteria].merge!({"gender" => "male"})
+        enquiry.gender = "male"
         enquiry.save!
 
         expect(enquiry.potential_matches.size).to eq(3)
@@ -147,12 +146,12 @@ describe Enquiry, :type => :model do
       it "should remove id that dont match anymore whenever criteria changes" do
         child1 = Child.create(:name => "eduardo aquiles", 'created_by' => "me", 'created_organisation' => "stc")
 
-        enquiry = Enquiry.create!(:criteria => {"name" => "eduardo"}, :enquirer_name => "Kisitu")
+        enquiry = Enquiry.create!(:name => "eduardo", :enquirer_name => "Kisitu")
 
         expect(enquiry.potential_matches.size).to eq(1)
         expect(enquiry.potential_matches).to eq([child1.id])
 
-        enquiry[:criteria].merge!("name" => "John")
+        enquiry.name = "John"
         enquiry.save!
 
         expect(enquiry.potential_matches.size).to eq(0)
@@ -163,12 +162,12 @@ describe Enquiry, :type => :model do
         child1 = Child.create(:name => "eduardo aquiles", 'created_by' => "me", 'created_organisation' => "stc")
         child2 = Child.create(:name => "foo bar", :location => "Kampala", 'created_by' => "me", 'created_organisation' => "stc")
 
-        enquiry = Enquiry.create!(:criteria => {"name" => "eduardo", "location" => "Kampala"}, :enquirer_name => "Kisitu")
+        enquiry = Enquiry.create!(:name => "eduardo", :location => "Kampala", :enquirer_name => "Kisitu")
 
         expect(enquiry.potential_matches.size).to eq(2)
         expect(enquiry.potential_matches).to include(child1.id, child2.id)
 
-        enquiry[:criteria].merge!("name" => "John")
+        enquiry.name = "John"
         enquiry.save!
 
         expect(enquiry.potential_matches.size).to eq(1)
@@ -179,7 +178,7 @@ describe Enquiry, :type => :model do
         child1 = Child.create(:name => "Eduardo aquiles", :location => "Kampala", 'created_by' => "me", 'created_organisation' => "stc")
         child2 = Child.create(:name => "Batman", :location => "Kampala", 'created_by' => "not me", 'created_organisation' => "stc")
 
-        enquiry = Enquiry.create!(:criteria => {"name" => "Eduardo", "location" => "Kampala"}, :enquirer_name => "Kisitu")
+        enquiry = Enquiry.create!(:name => "Eduardo", :location => "Kampala", :enquirer_name => "Kisitu")
 
         expect(enquiry.potential_matches.size).to eq(2)
         expect(enquiry.potential_matches).to eq([child1.id, child2.id])
@@ -199,7 +198,7 @@ describe Enquiry, :type => :model do
         end
 
         it "should update match_updated_at timestamp when new matching children are found on creation of an Enquiry" do
-          enquiry = Enquiry.create!(:criteria => {"name" => "Eduardo", "location" => "Kampala"}, :enquirer_name => "Kisitu")
+          enquiry = Enquiry.create!(:name => "Eduardo", :location => "Kampala", :enquirer_name => "Kisitu")
           expect(enquiry.match_updated_at).to eq(Time.utc(2013, "jan", 01, 00, 00, 0).to_s)
         end
 
@@ -210,12 +209,12 @@ describe Enquiry, :type => :model do
 
         it "should update match_updated_at timestamp when new matching children are found on updation of an Enquiry" do
 
-          enquiry = Enquiry.create!(:criteria => {"name" => "Eduardo"}, :enquirer_name => "Kisitu")
+          enquiry = Enquiry.create!(:name => "Eduardo", :enquirer_name => "Kisitu")
           expect(enquiry.match_updated_at).to eq(Time.utc(2013, "jan", 01, 00, 00, 0).to_s)
           expect(enquiry.potential_matches.size).to eq(1)
 
           allow(Clock).to receive(:now).and_return(Time.utc(2013, "jan", 02, 00, 00, 0).to_s)
-          enquiry.criteria.merge!({"location" => "Kampala"})
+          enquiry.location = "Kampala"
           enquiry.save!
 
           expect(enquiry.match_updated_at).to eq(Time.utc(2013, "jan", 02, 00, 00, 0).to_s)
@@ -239,6 +238,38 @@ describe Enquiry, :type => :model do
 
         expect(Enquiry.search_by_match_updated_since(DateTime.parse('2013-09-18 05:42:12UTC')).size).to eq(1)
         expect(Enquiry.search_by_match_updated_since(DateTime.parse('2013-09-18 06:42:12UTC')).size).to eq(1)
+      end
+    end
+
+    describe "generate_criteria" do
+      before :each do
+        reset_couchdb!
+
+        form = create :form, name: Enquiry::FORM_NAME
+
+        create :form_section, name: 'test_form', fields: [
+            build(:text_field, name: 'name'),
+            build(:text_field, name: 'location'),
+            build(:text_field, name: 'nationality'),
+            build(:text_field, name: 'enquirer_name'),
+            build(:numeric_field, name: 'age')
+        ], form: form
+      end
+
+      it "should generate criteria before saving" do
+        fields = {"name" => "Eduardo", "nationality" => "Ugandan", "enquirer_name" => "Subhas", "age" => "10", "location" => "Kampala"}
+        enquiry = Enquiry.new(fields)
+        enquiry.save!
+
+        expect(enquiry.criteria).to eq(fields)
+      end
+
+      it "should generate criteria before saving for filled in fields" do
+        fields = {"name" => "Eduardo", "nationality" => "Ugandan", "enquirer_name" => "Subhas", "age" => nil, "location" => "Kampala"}
+        enquiry = Enquiry.new(fields)
+        enquiry.save!
+
+        expect(enquiry.criteria).to eq(fields.keep_if { |key, value| !value.nil? })
       end
     end
 


### PR DESCRIPTION
@ctumwebaze @mwangiann rapidftr/tracker#152 Processing enquiries on the server

This fix changes the way enquiries were processed on the server. It introduces a criteria
generation step where a criteria is build from the fields on the form sections and the enquiry data
before the enquiry is actually saved.

previously the criteria was specified as part of the enquiry data when the server received it but that is not
necessary anymore since we generate it from the enquiries fields.
