### PR TITLE
 Bundling apk with server

### DIFF
--- a/docker/config/nginx-site.conf
+++ b/docker/config/nginx-site.conf
@@ -1,6 +1,20 @@
 server {
   listen 80;
-  rewrite ^(.*)$ https://$host$1 redirect;
+
+
+  location ~* ^.*/(.+\.(apk))$ {
+      root /rapidftr/public;
+
+      set $fname $1;
+      add_header Content-Description 'File Transfer';
+      add_header Content-Type 'application/vnd.android.package-archive';
+      add_header Content-Disposition 'attachment; filename="$fname"';
+      add_header Content-Transfer-Encoding: 'binary';
+  }
+
+  location / {
+    rewrite ^(.*)$ https://$host$1 redirect;
+  }
 }
 
 server {
@@ -26,6 +40,10 @@ server {
     expires max;
     add_header Cache-Control public;
     break;
+  }
+
+  location ~* ^.*/(.+\.(apk))$ {
+     rewrite ^(.*)$ http://$host$1 redirect;
   }
 }
 


### PR DESCRIPTION
@ctumwebaze @austiine04 rapidftr/tracker#52

This fix ensures that the apk is downloaded using http rather than https. This is because
if the server is using a self-signed certificate, the android device will not trust the certificate and
will go into an indefinate download loop.

This fix ensure that if a request for an apk comes in over https, it will be redirected to http.
