### PR TITLE
Style delete form section link

### DIFF
--- a/app/assets/stylesheets/new/_new_layout.scss
+++ b/app/assets/stylesheets/new/_new_layout.scss
@@ -597,6 +597,14 @@ body {
 }
 
 .form_page{
+  .form_delete {
+    position: absolute;
+    margin-top: -36px;
+    padding: 0 0 0 15px;
+    text-decoration: underline;
+    color: red;
+  }
+
   .form_details_panel{
     background: #eee;
     border:1px solid #ddd;

--- a/app/views/form_section/_form_section.html.erb
+++ b/app/views/form_section/_form_section.html.erb
@@ -2,8 +2,8 @@
                         :header_tag => :h3,
                         :header_message => t("form_section.messages.cannot_create"),
                         :message => t('form_section.messages.correct_errors') %>
-  <%= form_for @form_section, :url => url_for_form_section(@form_section, @form), :html => {:class => ""} do |f| %>
-    <div class="form_details_panel">
+  <div class="form_details_panel">
+    <%= form_for @form_section, :url => url_for_form_section(@form_section, @form), :html => {:class => ""} do |f| %>
       <div class="default_lang_panel">
         <div class="lang_title">
           <%= t("forms.initial_language") %> : <span><%= t("home.#{I18n.default_locale}") %></span>
@@ -45,5 +45,5 @@
         <%= cancel_button(form_form_sections_path(@form.id)) %>
         <%= submit_button t("forms.save_details") %>
       </div>
-    </div>
-  <% end %>
+    <% end %>
+  </div>

--- a/app/views/form_section/edit.html.erb
+++ b/app/views/form_section/edit.html.erb
@@ -2,8 +2,9 @@
   <span id='sectionId'><%= @form_section.name %></span></h1>
 <div class="page-content-new form_page">
 <div class="side-tab-content full_width">
-  <%= link_to I18n.t("user.actions.delete") + " " + @form_section.name, form_section_path(@form_section), { method: :delete, data: { confirm: I18n.t("messages.delete_form_section") }} %>
   <%= render :partial => "form_section/form_section" %>
+  <%= link_to I18n.t("user.actions.delete") + " " + @form_section.name, form_section_path(@form_section), { class: "form_delete", method: :delete, data: { confirm: I18n.t("messages.delete_form_section") }} %>
+
   <% if @form_section.editable? %>
     <h3><%= t("fields.label") %><%= link_to t("fields.add"), "javascript:void(0)", :class => "add_field" %></h3>
   <% else %>


### PR DESCRIPTION
Styled the "Delete form section" link to appear in the same line as other buttons.

References #693, rapidftr/tracker#136

/cc @robmiles @raoufaghrout @baziwane
