### PR TITLE
@robmiles @raoufaghrout rapidftr/tracker#136 Fixed functional test that ...

### DIFF
--- a/capybara_features/form_section_operation.feature
+++ b/capybara_features/form_section_operation.feature
@@ -204,11 +204,13 @@ Feature: So that admin can see Manage Form Sections Page, customize form section
     When I select menu "Basic Identity"
     Then I should not see "Nationality"
 
+  @javascript
   Scenario: Admins should be able to delete a field from a form section
     When I am on the form sections page for "Children"
     And I follow "Basic Identity"
     And I follow "characteristic_Delete"
-    Then I should not see "characteristic"
+    When I click OK in the browser popup
+    Then I should not see "Characteristic field" with id "fields_characteristic"
   
   @javascript
   Scenario: Admins should be able to delete form sections


### PR DESCRIPTION
While working on story rapidftr/tracker#136 we noticed that the functional test for deleting a field was not working as intended. The functional test ran and passed because it was checking "characteristic" exists on the page outside of HTML tags, where "Characteristic" (difference: upper case c) did still exist outside of HTML tags. The issue is that after delete is clicked the browser prompt to confirm the delete wasn't being clicked and hence the characteristic field on the page still existed. So the test as it was should have been failing.

The test has been changed to check the field has been removed using the id of that field, this is because the String "Characteristic" still exists on the page due to the confirmation message that is displayed. Additionally the test now uses javascript as it will need to confirm in the browser prompt if the delete should occur.

We weren't sure whether to add this as a bug or fix it as part of the existing story, if possible please provide guidance on how to proceed and some feedback. Hope this helps, please feel free to ask any questions or clarifications.

Thanks!
