### PR TITLE
rapidftr/tracker#177 @austiine04 ensures that enquiry creation informati...

### DIFF
--- a/app/helpers/record_helper.rb
+++ b/app/helpers/record_helper.rb
@@ -3,8 +3,8 @@ module RecordHelper
 
   # TODO: #40: Refactor created_at & posted_at to use CouchREST timestamps!
   def creation_fields_for(user)
-    self['created_by'] = user.try(:user_name)
-    self['created_organisation'] = user.try(:organisation)
+    self['created_by'] ||= user.try(:user_name)
+    self['created_organisation'] ||= user.try(:organisation)
     self['created_at'] ||= RapidFTR::Clock.current_formatted_time
     self['posted_at'] = RapidFTR::Clock.current_formatted_time
   end

--- a/spec/controllers/api/enquiries_controller_spec.rb
+++ b/spec/controllers/api/enquiries_controller_spec.rb
@@ -91,6 +91,22 @@ describe Api::EnquiriesController, :type => :controller do
       expect(response).to be_forbidden
       expect(JSON.parse(response.body)['error']).to eq('Forbidden')
     end
+
+    it 'should not overwrite creation information from mobile' do
+      allow(RapidFTR::Clock).to receive(:current_formatted_time).and_return('2014-08-26 08:15:22 +0000')
+      enquiry = {:enquirer_name => 'John Doe',
+                 :created_by => 'Foo Bar',
+                 :created_organisation => 'UNICEF',
+                 :created_at => '2014-08-25 08:15:22 +0000'}
+
+      post :create, :enquiry => enquiry
+
+      saved_enquiry = Enquiry.first
+      expect(saved_enquiry[:created_by]).to eq enquiry[:created_by]
+      expect(saved_enquiry[:created_at]).to eq enquiry[:created_at]
+      expect(saved_enquiry[:created_organisation]).to eq enquiry[:created_organisation]
+      expect(saved_enquiry[:posted_at]).to eq '2014-08-26 08:15:22 +0000'
+    end
   end
 
   describe 'PUT update' do


### PR DESCRIPTION
this fix ensures that enquiry creation information(created_at, created_by) doesnot get overidden by api
