### PR TITLE
rapidftr/tracker#180 syncing enquiries.

### DIFF
--- a/app/helpers/record_helper.rb
+++ b/app/helpers/record_helper.rb
@@ -43,11 +43,11 @@ module RecordHelper
 
   def add_creation_history
     self['histories'].unshift(
-                                'user_name' => created_by,
-                                'user_organisation' => organisation_of(created_by),
-                                'datetime' => created_at,
-                                'changes' => {self.class.name.downcase => {:created => created_at}}
-                              )
+        'user_name' => created_by,
+        'user_organisation' => organisation_of(created_by),
+        'datetime' => created_at,
+        'changes' => {self.class.name.downcase => {:created => created_at}}
+    )
   end
 
   def update_with_attachments(params, user)
@@ -75,10 +75,10 @@ module RecordHelper
   def add_to_history(changes)
     last_updated_user_name = last_updated_by
     self['histories'].unshift(
-                                'user_name' => last_updated_user_name,
-                                'user_organisation' => organisation_of(last_updated_user_name),
-                                'datetime' => last_updated_at,
-                                'changes' => changes)
+        'user_name' => last_updated_user_name,
+        'user_organisation' => organisation_of(last_updated_user_name),
+        'datetime' => last_updated_at,
+        'changes' => changes)
   end
 
   def organisation_of(user_name)
@@ -94,10 +94,7 @@ module RecordHelper
 
   def changes_for(field_names)
     field_names.reduce({}) do |changes, field_name|
-      changes.merge(field_name => {
-                      'from' => original_data[field_name],
-                      'to' => self[field_name]
-                    })
+      changes.merge(field_name => {'from' => original_data[field_name], 'to' => self[field_name]})
     end
   end
 

--- a/app/models/enquiry.rb
+++ b/app/models/enquiry.rb
@@ -1,14 +1,20 @@
 class Enquiry < CouchRest::Model::Base
   use_database :enquiry
+
+  require 'uuidtools'
   include RecordHelper
   include RapidFTR::CouchRestRailsBackward
   include Searchable
+
+  after_initialize :create_unique_id
 
   before_validation :create_criteria, :on => [:create, :update]
   before_save :find_matching_children
   before_save :update_history, :unless => :new?
   before_save :add_creation_history, :if => :new?
 
+  property :short_id
+  property :unique_identifier
   property :criteria, Hash
   property :potential_matches, :default => []
   property :match_updated_at, :default => ''
@@ -150,6 +156,11 @@ class Enquiry < CouchRest::Model::Base
   end
 
   private
+
+  def create_unique_id
+    self.unique_identifier ||= UUIDTools::UUID.random_create.to_s
+    self.short_id = unique_identifier.last 7
+  end
 
   def create_criteria
     self.criteria = {}

--- a/spec/controllers/api/enquiries_controller_spec.rb
+++ b/spec/controllers/api/enquiries_controller_spec.rb
@@ -111,24 +111,6 @@ describe Api::EnquiriesController, :type => :controller do
 
   describe 'PUT update' do
 
-    it 'should not update record when criteria is empty' do
-      enquiry = Enquiry.create(:enquirer_name => 'Someone', :name => 'child name')
-      allow(controller).to receive(:authorize!)
-
-      put :update, :id => enquiry.id, :enquiry => {:id => enquiry.id, :enquirer_name => nil, :name => nil}, :format => :json
-
-      expect(response.response_code).to eq(422)
-    end
-
-    it 'should not update record when there is no criteria' do
-      enquiry = Enquiry.create(:enquirer_name => 'Someone', :name => 'child name')
-      allow(controller).to receive(:authorize!)
-
-      put :update, :id => enquiry.id, :enquiry => {:id => enquiry.id, :enquirer_name => nil, :name => nil}, :format => :json
-
-      expect(response.response_code).to eq(422)
-    end
-
     it 'should trigger the match functionality every time a record is created' do
       criteria = {'name' => 'old name'}
       enquiry = Enquiry.create(:enquirer_name => 'Machaba', :reporter_details => {'location' => 'kampala'}, :criteria => criteria)
@@ -142,8 +124,7 @@ describe Api::EnquiriesController, :type => :controller do
     end
 
     it 'should not trigger the match unless record is created' do
-      criteria = {'name' => 'old name'}
-      enquiry = Enquiry.create(:enquirer_name => 'Machaba', :reporter_details => {'location' => 'kampala'}, :criteria => criteria)
+      enquiry = Enquiry.create(:enquirer_name => 'Machaba', :reporter_details => {'location' => 'kampala'})
       allow(controller).to receive(:authorize!)
 
       expect(Enquiry).not_to receive(:find_matching_children)
@@ -239,14 +220,11 @@ describe Api::EnquiriesController, :type => :controller do
       child1 = Child.create('name' => 'Clayton aquiles', 'created_by' => 'fakeadmin', 'created_organisation' => 'stc')
       child2 = Child.create('name' => 'Steven aquiles', 'sex' => 'male', 'created_by' => 'fakeadmin', 'created_organisation' => 'stc')
 
-      enquiry_json = "{\"enquirer_name\": \"Godwin\",\"sex\": \"male\",\"age\": \"10\",\"location\": \"Kampala\" }"
-      enquiry = Enquiry.new(JSON.parse(enquiry_json))
-      enquiry.save!
+      enquiry = Enquiry.create(:enquirer_name => 'Godwin', :sex => 'male', :age => '10', :location => 'Kampala')
+
       expect(Enquiry.get(enquiry.id)['potential_matches']).to include(*[child2.id])
 
-      updated_enquiry = "{\"name\": \"aquiles\", \"age\": \"10\", \"location\": \"Kampala\"}"
-
-      put :update, :id => enquiry.id, :enquiry => updated_enquiry
+      put :update, :id => enquiry.id, :enquiry => {:name => 'aquiles', :age => '10', :location => 'Kampala'}
       expect(response.response_code).to eq(200)
 
       enquiry_after_update = Enquiry.get(enquiry.id)

--- a/spec/models/enquiry_spec.rb
+++ b/spec/models/enquiry_spec.rb
@@ -33,7 +33,6 @@ describe Enquiry, :type => :model do
       it 'should update the enquiry' do
         enquiry = create_enquiry_with_created_by('jdoe', :enquirer_name => 'Vivek', :place => 'Kampala')
         properties = {:enquirer_name => 'DJ', :place => 'Kampala'}
-
         enquiry.update_from(properties)
 
         expect(enquiry.enquirer_name).to eq('DJ')


### PR DESCRIPTION
@ctumwebaze @mwangiann
When synchronizing enquiries from the mobile to the web, it was failing due to that fact that the mobile
device was sending along particular fields that are couchdb system fields i.e '_rev' that were causing conflicts.

This fix extends the functionality of the enquiries to allow.
1. creation of a unique identifier for an enquiry before saving it. This is important because the mobile device requires this
field to be present to avoid creation of duplicate records when synchronizing.
2. dealing with history logs of an enquiry during synch.
