### PR TITLE
Fix coveralls behaviour

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -4,6 +4,11 @@
 # instead of editing this one. Cucumber will automatically load all features/**/*.rb
 # files.
 
+if ENV['COVERALLS']
+  require 'coveralls'
+  Coveralls.wear_merged!('rails')
+end
+
 ENV['RAILS_ENV'] = 'cucumber'
 $LOAD_PATH.unshift(File.expand_path(File.dirname(__FILE__) + '/../..'))
 
@@ -14,11 +19,6 @@ require 'spec/support/child_finder'
 require 'json_spec/cucumber'
 require 'rack/test'
 require 'selenium/webdriver'
-
-if ENV['COVERALLS']
-  require 'coveralls'
-  Coveralls.wear_merged!('rails')
-end
 
 Capybara.register_driver :selenium do |app|
   http_client = Selenium::WebDriver::Remote::Http::Default.new


### PR DESCRIPTION
Coveralls was exhibiting erratic behaviour, showing coverage for a total of only 6 files yet there are over 90 relevant files, and haphazardly showing alternating statistics (see this [comment](https://github.com/rapidftr/RapidFTR/pull/705#issuecomment-52401596), as well as [this one](https://github.com/rapidftr/RapidFTR/pull/706#issuecomment-52414394), and the screenshot below):

![screen shot 2014-09-08 at 3 54 23 pm](https://cloud.githubusercontent.com/assets/5906754/4185482/5ad66392-3757-11e4-8fb6-b70ecdb1abb7.png)

It appears that this was because in the `features/support/env.rb` we were requiring coveralls after some other application code had already been required
