### PR TITLE
rapidftr/tracker#65 ordering potential matches by relevance.

### DIFF
--- a/app/assets/stylesheets/new/_entity_summary.scss
+++ b/app/assets/stylesheets/new/_entity_summary.scss
@@ -1,20 +1,19 @@
 .entity_list {
   @extend .clearfix;
 
-
   .entity_summary_panel {
     background: $bg-child-summary;
     border: 1px solid $border-child-summary;
     @include borderRadius(2px);
     margin: 10px 0px;
-    float:left;
+    float: left;
     width: 100%;
     @extend .clearfix;
 
-    p.checkbox{
+    p.checkbox {
       background: #EEE;
       border: 1px solid #D4D1D1;
-      border-right:0px;
+      border-right: 0px;
       left: -231px;
       padding: 5px;
       position: absolute;
@@ -26,16 +25,16 @@
       width: 160px;
       height: 160px;
 
-      margin:10px;
+      margin: 10px;
       background: #fff;
       border: 10px solid #fff;
     }
 
-    .photos, .audio{
+    .photos, .audio {
       margin-right: 220px;
     }
 
-    .photos .thumbnail{
+    .photos .thumbnail {
       float: left;
       margin: 2px;
       height: 140px;
@@ -44,7 +43,7 @@
     .summary_panel {
       float: left;
       padding: 10px 10px 10px 0px;
-      width:auto;
+      width: auto;
       max-width: 78%;
       min-width: 70%;
       position: relative;
@@ -52,24 +51,24 @@
       h2 {
         font-size: 1.4em;
 
-        padding:5px 10px 10px 0px;
+        padding: 5px 10px 10px 0px;
       }
 
-      .flag{
-        position:absolute;
-        top:0px;
-        width:22px;
-        height:36px;
+      .flag {
+        position: absolute;
+        top: 0px;
+        width: 22px;
+        height: 36px;
       }
 
-      .reunited{
-        right:10px;
-        background:image-url('new/icon_reunited.png') no-repeat;
+      .reunited {
+        right: 10px;
+        background: image-url('new/icon_reunited.png') no-repeat;
       }
 
-      .suspect{
+      .suspect {
         right: 40px;
-        background:image-url('new/icon_flagged.png') no-repeat;
+        background: image-url('new/icon_flagged.png') no-repeat;
       }
 
       .photowall {
@@ -77,26 +76,25 @@
         background: image-url('new/icon_photowall.png') no-repeat;
       }
 
-      .summary_item{
+      .summary_item {
         @extend .clearfix;
         border-top: 1px solid #ddd;
         font-size: 0.95em;
 
-      .key {
-        color: #666;
-        padding:10px 0px 10px 20px;
-        float: left;
-        width:180px;
-      }
-      .value {
-        color: #000;
-        padding:10px;
-        float:left;
-        /*width:470px;*/
+        .key {
+          color: #666;
+          padding: 10px 0px 10px 20px;
+          float: left;
+          width: 180px;
+        }
+        .value {
+          color: #000;
+          padding: 10px;
+          float: left;
+          /*width:470px;*/
 
+        }
       }
-      }
-
     }
 
     .action_panel {
@@ -104,33 +102,43 @@
       padding: 5px 10px 8px;
       border-top: 1px solid $border-child-summary;
       font-size: 1.3em;
-      color:#aaa;
+      color: #aaa;
 
-        a{
-            margin:0px 10px;
-            font-size: 0.8em;
-        }
+      a {
+        margin: 0px 10px;
+        font-size: 0.8em;
+      }
 
-      li{
+      li {
         display: inline;
       }
 
     }
+
+    .left_side {
+      float: left;
+    }
+
+    .score_panel h2 {
+      text-align: center;
+      width: 100%;
+      font-size: 2em !important;
+    }
   }
 
-  .results-count{
+  .results-count {
     float: right;
     margin: 0 26px 0 0;
     color: #4b515f;
   }
 
-  .child_summary_panel.sel{
-    background:#e5efff;
-    border:1px solid #bdd7ff;
+  .child_summary_panel.sel {
+    background: #e5efff;
+    border: 1px solid #bdd7ff;
 
-    p.checkbox{
-      background:#e5efff;
-      border:1px solid #bdd7ff;
+    p.checkbox {
+      background: #e5efff;
+      border: 1px solid #bdd7ff;
       border-right: 0px;
     }
   }

--- a/app/controllers/system_variables_controller.rb
+++ b/app/controllers/system_variables_controller.rb
@@ -1,0 +1,22 @@
+class SystemVariablesController < ApplicationController
+  def index
+    authorize! :read, SystemUsers
+    @system_variables = SystemVariable.all.all
+  end
+
+  def update
+    authorize! :update, SystemUsers
+    params[:system_variables].keys.each do |id|
+      variable = SystemVariable.find(id)
+      old_value = variable.value
+      variable.value = params[:system_variables][id]
+      variable.save!
+
+      if variable.name == SystemVariable::SCORE_THRESHOLD && variable.value != old_value
+        Enquiry.update_all_child_matches
+      end
+    end
+
+    redirect_to system_variables_path
+  end
+end

--- a/app/models/child.rb
+++ b/app/models/child.rb
@@ -198,8 +198,8 @@ rescue
     previous_matches = potential_matches
     criteria = Child.build_text_fields_for_solar.map { |field_name| self[field_name] unless self[field_name].nil? }
     criteria.reject! { |c| c.nil? || c.empty? }
-    enquiries = MatchService.search_for_matching_enquiries(criteria)
-    PotentialMatch.create_matches_for_child id, enquiries.map(&:id)
+    hits = MatchService.search_for_matching_enquiries(criteria)
+    PotentialMatch.create_matches_for_child id, hits
 
     unless previous_matches.eql?(potential_matches)
       self.match_updated_at = Clock.now.to_s

--- a/app/models/match_service.rb
+++ b/app/models/match_service.rb
@@ -6,7 +6,9 @@ class MatchService
       search = Sunspot.search(Enquiry) do
         fulltext criteria.join(' '), :fields => Enquiry.matchable_fields.map(&:name), :minimum_match => 1
       end
-      return search.results
+      results = {}
+      search.hits.each { |hit| results[hit.result.id] = hit.score }
+      return results
     end
   end
 
@@ -17,7 +19,9 @@ class MatchService
       search = Sunspot.search(Child) do
         fulltext criteria.values.join(' '), :minimum_match => 1
       end
-      return search.results
+      results = {}
+      search.hits.each { |hit| results[hit.result.id] = hit.score }
+      return results
     end
   end
 end

--- a/app/models/potential_match.rb
+++ b/app/models/potential_match.rb
@@ -5,6 +5,8 @@ class PotentialMatch < CouchRest::Model::Base
   belongs_to :child
   property :marked_invalid, TrueClass, :default => false
   property :confirmed, TrueClass, :default => false
+  property :score, String
+  property :deleted, TrueClass, :default => false
   timestamps!
   validates :child_id, :uniqueness => {:scope => :enquiry_id}
 
@@ -12,6 +14,8 @@ class PotentialMatch < CouchRest::Model::Base
     view :by_enquiry_id
     view :by_enquiry_id_and_child_id
     view :by_enquiry_id_and_confirmed
+    view :by_enquiry_id_and_marked_invalid
+    view :by_enquiry_id_and_deleted
     view :by_child_id_and_confirmed
     view :all_valid_enquiry_ids,
          :map => "function(doc) {
@@ -29,16 +33,16 @@ class PotentialMatch < CouchRest::Model::Base
   end
 
   class << self
-    def create_matches_for_child(child_id, enquiry_ids)
-      enquiry_ids.each do |id|
-        pm = PotentialMatch.new :enquiry_id => id, :child_id => child_id
+    def create_matches_for_child(child_id, hits)
+      hits.each do |enquiry_id, score|
+        pm = PotentialMatch.new :enquiry_id => enquiry_id, :child_id => child_id, :score => score
         pm.save
       end
     end
 
-    def create_matches_for_enquiry(enquiry_id, child_ids)
-      child_ids.each do |id|
-        pm = PotentialMatch.new :enquiry_id => enquiry_id, :child_id => id
+    def create_matches_for_enquiry(enquiry_id, hits)
+      hits.each do |child_id, score|
+        pm = PotentialMatch.new :enquiry_id => enquiry_id, :child_id => child_id, :score => score
         pm.save
       end
     end

--- a/app/models/system_variable.rb
+++ b/app/models/system_variable.rb
@@ -1,0 +1,15 @@
+class SystemVariable < CouchRest::Model::Base
+  use_database :system_setting
+
+  property :name, String
+  property :value, String
+
+  validates :name, :presence => true, :uniqueness => true
+  validates :value, :presence => true
+
+  design do
+    view :by_name
+  end
+
+  SCORE_THRESHOLD = 'SCORE_THRESHOLD'
+end

--- a/app/views/admin/index.html.slim
+++ b/app/views/admin/index.html.slim
@@ -11,6 +11,10 @@ h1
 - if can? :manage, SystemUsers
   br
   p
+    = link_to t("admin.system_variables"), system_variables_path
+- if can? :manage, SystemUsers
+  br
+  p
     = link_to t("admin.manage_system_users"), system_users_path
 = form_tag admin_update_path, :method => "put"  do
   = label_tag "user_locale", t("home.language")

--- a/app/views/children/_summary_row.html.erb
+++ b/app/views/children/_summary_row.html.erb
@@ -1,8 +1,17 @@
 <!-- BEGIN: item -->
 <div id="child_<%= child.id %>" class="entity_summary_panel">
 
-  <div class="photo_panel">
-    <%= link_to thumbnail_tag(child, child.primary_photo_id), child_path(child.id) %>
+  <div class="left_side">
+    <div class="photo_panel">
+      <%= link_to thumbnail_tag(child, child.primary_photo_id), child_path(child.id) %>
+    </div>
+    <% if local_assigns.has_key?(:score) && !:score.nil?%>
+      <div class="score_panel" >
+        <h2>
+          <%= score.to_s[0..4] %>
+        </h2>
+      </div>
+    <% end %>
   </div>
   <div class="summary_panel">
     <% if checkbox %>

--- a/app/views/enquiries/_potential_matches.html.erb
+++ b/app/views/enquiries/_potential_matches.html.erb
@@ -18,8 +18,8 @@
   <div class="clearfix"></div>
   <div class="form_info"></div>
   <div class="entity_list">
-    <% @enquiry.potential_matches.each do |child| %>
-      <%= render :partial => "children/summary_row", :locals => {:child => child, :confirmed_match => confirmed_match, :checkbox => false, :highlighted_fields => child_sorted_highlighted_fields, :rendered_by_show_enquiry => true} %>
-  <% end %>
+    <% @enquiry.potential_matches.each do |match| %>
+      <%= render :partial => "children/summary_row", :locals => {:child => match.child, :score => match.score, :confirmed_match => confirmed_match, :checkbox => false, :highlighted_fields => child_sorted_highlighted_fields, :rendered_by_show_enquiry => true} %>
+    <% end %>
   </div>
 </fieldset>

--- a/app/views/system_variables/index.html.erb
+++ b/app/views/system_variables/index.html.erb
@@ -1,0 +1,25 @@
+<h1 class="no_border float_left"><%= t('admin.manage_system_variables') %> </h1>
+
+<%= form_tag({:controller => 'system_variables', :action => 'update'}, :method => 'PATCH') do %>
+  <table class="list_table">
+    <thead>
+    <tr>
+      <th><%= t('admin.key') %></th>
+      <th colspan="2"><%= t('admin.value') %></th>
+    </tr>
+    </thead>
+
+    <tbody>
+    <% @system_variables.each do |variable| %>
+        <tr id="system-row-<%= variable.name %>">
+          <td><%= variable.name %></td>
+          <td>
+            <%= text_field_tag "system_variables[#{variable.id}]", variable.value, :type => 'number', :step => '0.001', :min => '0'%>
+          </td>
+          </td>
+        </tr>
+    <% end %>
+    </tbody>
+  </table>
+  <button type="submit"><%= t('buttons.save')%></button>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -465,6 +465,10 @@ en:
     manage_system_users: "Manage Server Synchronisation Users"
     create_system_user: Create a System User
     system_logs: "System Logs"
+    system_variables: "System Variables"
+    manage_system_variables: "Manage System Variables"
+    key: "Key"
+    value: "Value"
 
   fields:
     label: "Fields"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -191,6 +191,9 @@ RapidFTR::Application.routes.draw do
 
   resources :system_users, :path => '/admin/system_users'
 
+  resources :system_variables, :path => '/admin/system_variables', :controller => 'system_variables', :except => [:update]
+  match '/admin/system_variables' => 'system_variables#update', :via => [:put, :patch]
+
   #######################
   # REPORTING URLS
   #######################

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -70,3 +70,7 @@ if should_seed? FormSection
   end
   RapidFTR::I18nSetup.reset_definitions
 end
+
+if should_seed? SystemVariable
+  SystemVariable.create(:name => SystemVariable::SCORE_THRESHOLD, :value => '0.00')
+end

--- a/features/enquiry_potential_matches.feature
+++ b/features/enquiry_potential_matches.feature
@@ -129,3 +129,15 @@ Feature:
     And I confirm child match with unique_id "zubairlon456"
     And I follow "Undo Confirmation"
     Then I should not see "Confirmed Matches"
+
+  @javascript
+  Scenario: View potential Matches score for enquiry
+    Given I am logged in as a user with "Create Enquiry,View Enquiries" permissions
+    When I follow "Register New Enquiry"
+    And I fill in "Enquirer Name" with "Charles"
+    And I fill in "Child's Name" with "John Doe"
+    And I fill in "Location" with "London"
+    And I press "Save"
+    Then I follow "Matches"
+    And I should see "2" children on the page
+    And I should see "2" scores on the page

--- a/features/step_definitions/basic_steps.rb
+++ b/features/step_definitions/basic_steps.rb
@@ -292,3 +292,10 @@ def destroy_form(form_name)
   form.sections.each { |section| section.destroy } unless form.nil?
   form.destroy unless form.nil?
 end
+
+Given(/^the following system variables exist in the system$/) do |table|
+  # table is a table.hashes.keys # => [:name, :value]
+  table.hashes.each do | system_variables_hash|
+    SystemVariable.create(:name => system_variables_hash['name'], :value => system_variables_hash['value'])
+  end
+end

--- a/features/step_definitions/children_listing_steps.rb
+++ b/features/step_definitions/children_listing_steps.rb
@@ -30,6 +30,10 @@ When /^I sort "(.*?)"$/  do |sort_order|
   child_list_page.sort(sort_order)
 end
 
+Then(/^I should see "(.*?)" scores on the page$/) do |number_of_records|
+  child_list_page.should_be_showing_score(number_of_records.to_i)
+end
+
 private
 
 def child_list_page

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -12,6 +12,11 @@ Before do
   RSpec::Mocks.space.proxy_for(Clock).reset
 
   Sunspot.remove_all!(Child, Enquiry)
+
+  score_threshold_variable = SystemVariable.find_by_name(SystemVariable::SCORE_THRESHOLD)
+  if score_threshold_variable.nil?
+    SystemVariable.create(:name => SystemVariable::SCORE_THRESHOLD, :value => '0.00')
+  end
 end
 
 Before('@roles') do |_scenario|

--- a/features/support/pages/entity_list_page.rb
+++ b/features/support/pages/entity_list_page.rb
@@ -45,6 +45,10 @@ class EntityListPage
     end
   end
 
+  def should_be_showing_score(score_count)
+    expect(@session.all(:css, CHILD_SCORE_PANEL_SELECTOR).count).to eq score_count
+  end
+
   PAGINATION_SELECTOR = 'div.pagination'
   PREV_PAGE_LINK_SELECTOR =  "#{PAGINATION_SELECTOR} a.previous_page"
   NEXT_PAGE_LINK_SELECTOR = "#{PAGINATION_SELECTOR} a.next_page"
@@ -52,4 +56,5 @@ class EntityListPage
   NEXT_PAGE_DISABLED_LINK_SELECTOR = "#{PAGINATION_SELECTOR} span.next_page"
   CURRENT_PAGE_INDICATOR_SELECTOR = "#{PAGINATION_SELECTOR} em.current"
   CHILD_SUMMARY_PANEL_SELECTOR = '.entity_summary_panel'
+  CHILD_SCORE_PANEL_SELECTOR = '.score_panel'
 end

--- a/features/system_settings_access.feature
+++ b/features/system_settings_access.feature
@@ -19,3 +19,19 @@ Feature: Only users with System Settings permission should have access to certai
     And I should be able to see manage users page
     And I should not be able to see the form sections page for "Children"
     And I should not be able to see the edit form section page for "basic_details"
+
+  Scenario: An admin can view a list of system variables
+    Given the following system variables exist in the system
+      | name                         | value |
+      | SOLR_SCORE_THRESHOLD         | 2.0   |
+      | USER_SESSION_TIMEOUT_MINUTES | 20    |
+    Given I am logged in as an admin
+    And I follow "System Settings"
+    And I follow "System Variables"
+    Then I should see "Manage System Variables"
+    And I should see "SOLR_SCORE_THRESHOLD"
+    And I should see "USER_SESSION_TIMEOUT_MINUTES"
+
+
+
+

--- a/spec/controllers/api/enquiries_controller_spec.rb
+++ b/spec/controllers/api/enquiries_controller_spec.rb
@@ -19,7 +19,7 @@ describe Api::EnquiriesController, :type => :controller do
       build(:numeric_field, :name => 'age'),
       build(:text_field, :name => 'gender')
     ], :form => form
-
+    allow(SystemVariable).to receive(:find_by_name).and_return(double(:value => '0.00'))
   end
 
   describe '#authorizations' do
@@ -220,15 +220,15 @@ describe Api::EnquiriesController, :type => :controller do
 
       enquiry = Enquiry.create(:enquirer_name => 'Godwin', :sex => 'male', :age => '10', :location => 'Kampala')
 
-      expect(Enquiry.get(enquiry.id).potential_matches).to include(child2)
+      expect(Enquiry.get(enquiry.id).potential_matches.map(&:child)).to include(child2)
 
       put :update, :id => enquiry.id, :enquiry => {:child_name => 'aquiles', :age => '10', :location => 'Kampala'}
       expect(response.response_code).to eq(200)
 
       enquiry_after_update = Enquiry.get(enquiry.id)
       expect(enquiry_after_update.potential_matches.size).to eq(2)
-      expect(enquiry_after_update.potential_matches).to include(child1)
-      expect(enquiry_after_update.potential_matches).to include(child2)
+      expect(enquiry_after_update.potential_matches.map(&:child)).to include(child1)
+      expect(enquiry_after_update.potential_matches.map(&:child)).to include(child2)
       expect(enquiry_after_update['criteria']).to eq('child_name' => 'aquiles', 'age' => '10', 'location' => 'Kampala', 'sex' => 'male')
     end
   end

--- a/spec/controllers/enquiries_controller_spec.rb
+++ b/spec/controllers/enquiries_controller_spec.rb
@@ -5,6 +5,7 @@ describe EnquiriesController, :type => :controller do
   before :each do
     reset_couchdb!
     @session = fake_field_worker_login
+    allow(SystemVariable).to receive(:find_by_name).and_return(double(:value => '0.00'))
   end
 
   describe '#new' do

--- a/spec/controllers/potential_matches_controller_spec.rb
+++ b/spec/controllers/potential_matches_controller_spec.rb
@@ -3,12 +3,14 @@ require 'spec_helper'
 describe PotentialMatchesController, :type => :controller do
 
   before :each do
+    reset_couchdb!
     FormSection.all.each { |fs| fs.destroy }
     fake_field_worker_login
+    allow(SystemVariable).to receive(:find_by_name).and_return(double(:value => '0.00'))
     @child = create(:child, :name => 'John Doe', :gender => 'male')
     form = create(:form, :name => Enquiry::FORM_NAME)
     @form_section = create(:form_section, :name => 'enquiry_criteria', :form => form, :fields => [build(:text_field, :name => 'enquirer_name')])
-    allow(MatchService).to receive(:search_for_matching_children).and_return([@child])
+    allow(MatchService).to receive(:search_for_matching_children).and_return(@child.id => '0.1')
     @enquiry = create(:enquiry, :enquirer_name => 'Foo Bar')
     allow(controller.current_ability).to receive(:can?).with(:update, Enquiry).and_return(true)
   end

--- a/spec/controllers/system_variables_controller_spec.rb
+++ b/spec/controllers/system_variables_controller_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+describe SystemVariablesController, :type => :controller do
+
+  before :each do
+    fake_admin_login
+    SystemVariable.all.all.each(&:destroy)
+  end
+
+  it 'should render the defined system variables' do
+    variable1 = SystemVariable.create(:name => 'Testing', :value => '23')
+    variable2 = SystemVariable.create(:name => 'Testing2', :value => '23323')
+
+    get(:index)
+
+    expect(assigns[:system_variables]).to include(variable1, variable2)
+  end
+
+  it 'should update defined system variables' do
+    variable = SystemVariable.create(:name => 'Testing', :value => '2343')
+
+    params = {:system_variables => {variable.id => '23'}}
+    put :update, params
+    expect(SystemVariable.all.first.value).to eq('23')
+  end
+
+  it 'should trigger update of potential matches when the score threshold changes.' do
+    variable = SystemVariable.create(:name => SystemVariable::SCORE_THRESHOLD, :value => '2343')
+    params = {:system_variables => {variable.id => '23'}}
+    Enquiry.should_receive(:update_all_child_matches)
+    put :update, params
+  end
+
+  it 'should not trigger an update of potential matches when the other variables are updated' do
+    variable = SystemVariable.create(:name => 'Testing', :value => '2343')
+    params = {:system_variables => {variable.id => '23'}}
+    Enquiry.should_not_receive(:update_all_child_matches)
+    put :update, params
+  end
+
+  it 'should not trigger an update for potential matches when the score threshold value doesnot change' do
+    variable = SystemVariable.create(:name => SystemVariable::SCORE_THRESHOLD, :value => '2343')
+    params = {:system_variables => {variable.id => '2343'}}
+    Enquiry.should_not_receive(:update_all_child_matches)
+    put :update, params
+  end
+end

--- a/spec/integration/solar_spec.rb
+++ b/spec/integration/solar_spec.rb
@@ -46,6 +46,7 @@ describe 'Enquiry Mapping', :type => :request, :solr => true do
   before :each do
     Sunspot.remove_all(Child)
     reset_couchdb!
+    allow(SystemVariable).to receive(:find_by_name).and_return(double(:value => '0.00'))
 
     @child1 = create(:child, 'last_known_location' => 'New York', 'name' => 'Mohammed Smith')
     @child2 = create(:child, 'last_known_location' => 'New York', 'name' => 'Muhammed Jones')

--- a/spec/models/child_spec.rb
+++ b/spec/models/child_spec.rb
@@ -679,12 +679,13 @@ describe Child, :type => :model do
 
     it 'should be triggered after save' do
       enquiry = build(:enquiry, :child_name => 'Eduardo')
-      allow(MatchService).to receive(:search_for_matching_enquiries).and_return([enquiry])
+      allow(MatchService).to receive(:search_for_matching_enquiries).and_return(enquiry.id => '0.9')
       child = create(:child, :name => 'Eduardo')
 
       expect(PotentialMatch.count).to eq(1)
       expect(PotentialMatch.first.child_id).to eq(child.id)
       expect(PotentialMatch.first.enquiry_id).to eq(enquiry.id)
+      expect(PotentialMatch.first.score).to eq('0.9')
     end
   end
 

--- a/spec/models/potential_match_spec.rb
+++ b/spec/models/potential_match_spec.rb
@@ -12,50 +12,39 @@ describe PotentialMatch, :type => :model do
       form = create :form, :name => Child::FORM_NAME
       field = build :field, :highlighted => true
       create :form_section, :form => form, :fields => [field]
+
+      allow(SystemVariable).to receive(:find_by_name).and_return(double(:value => '0.00'))
     end
 
     it 'should create potential match for a child' do
-      PotentialMatch.create_matches_for_child '1a3efc', ['2e453c']
-
-      expect(PotentialMatch.count).to eq 1
-      expect(PotentialMatch.first.child_id).to eq '1a3efc'
-      expect(PotentialMatch.first.enquiry_id).to eq '2e453c'
-    end
-
-    it 'should create potential matches for a child' do
-      PotentialMatch.create_matches_for_child '1a3efc', %w(2e453c 2ef1g)
+      PotentialMatch.create_matches_for_child('1a3efc', '2e453c' => '0.9', '23edsd' => '0.4')
 
       expect(PotentialMatch.count).to eq 2
       potential_matches = PotentialMatch.all.all
       child_ids = potential_matches.map(&:child_id)
       expect(child_ids).to include('1a3efc')
-      enquiry_ids = potential_matches.map(&:enquiry_id)
-      expect(enquiry_ids).to include('2e453c', '2ef1g')
-    end
-
-    it 'should create potential match for an enquiry' do
-      PotentialMatch.create_matches_for_enquiry '1a3efc', ['2e453c']
-
-      expect(PotentialMatch.count).to eq 1
-      expect(PotentialMatch.first.enquiry_id).to eq '1a3efc'
-      expect(PotentialMatch.first.child_id).to eq '2e453c'
+      scores = {}
+      potential_matches.each { |pm| scores[pm.enquiry_id] = pm.score }
+      expect(scores).to include('2e453c' => '0.9', '23edsd' => '0.4')
     end
 
     it 'should create potential matches for an enquiry' do
-      PotentialMatch.create_matches_for_enquiry '1a3efc', %w(2e453c 2ef1g)
+      PotentialMatch.create_matches_for_enquiry('1a3efc', '2e453c' => '0.9', '2ef1g' => '0.4')
 
       expect(PotentialMatch.count).to eq 2
       potential_matches = PotentialMatch.all.all
       enquiry_ids = potential_matches.map(&:enquiry_id)
       expect(enquiry_ids).to include('1a3efc')
-      child_ids = potential_matches.map(&:child_id)
-      expect(child_ids).to include('2e453c', '2ef1g')
+      scores = {}
+      potential_matches.each { |pm| scores[pm.child_id] = pm.score }
+      expect(scores).to include('2e453c' => '0.9', '2ef1g' => '0.4')
     end
   end
 
   describe 'uniqueness of enquiry id and child id' do
     before :each do
       PotentialMatch.all.each { |pm| pm.destroy }
+      allow(SystemVariable).to receive(:find_by_name).and_return(double(:value => '0.00'))
     end
 
     it 'should assure that potential_matches contains no duplicates' do
@@ -83,6 +72,7 @@ describe PotentialMatch, :type => :model do
 
     before :each do
       allow(User).to receive(:find_by_user_name).and_return(double(:organisation => 'stc'))
+      allow(SystemVariable).to receive(:find_by_name).and_return(double(:value => '0.00'))
       reset_couchdb!
       Sunspot.setup(Child) do
         text :location

--- a/spec/models/system_variable_spec.rb
+++ b/spec/models/system_variable_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+describe SystemVariable, :type => :model do
+
+  before :each do
+    SystemVariable.all.all.each(&:destroy)
+  end
+
+  describe 'settings' do
+
+    it 'should fail to save if key/name is nil' do
+      score_threshold_setting = SystemVariable.new :name => nil, :value => 'value'
+      score_threshold_setting.save
+
+      expect(score_threshold_setting).not_to be_valid
+    end
+
+    it 'should fail to save if value is null' do
+      score_threshold_setting = SystemVariable.new :name => 'SCORE_THRESHOLD', :value => nil
+      score_threshold_setting.save
+
+      expect(score_threshold_setting).not_to be_valid
+    end
+
+    it 'should fail to save if value and name are both nil' do
+      score_threshold_setting = SystemVariable.new :name => nil?, :value => nil
+      score_threshold_setting.save
+
+      expect(score_threshold_setting).not_to be_valid
+    end
+
+    it 'should fail to save if name already exists' do
+      score_threshold_setting = SystemVariable.new :name => 'SCORE_THRESHOLD', :value => '23'
+      score_threshold_setting.save
+      expect(score_threshold_setting).to be_valid
+
+      setting = SystemVariable.new :name => 'SCORE_THRESHOLD', :value => '2344343'
+      setting.save
+      expect(setting).not_to be_valid
+    end
+
+    it 'should find a setting with a particular name' do
+      SystemVariable.create(:name => 'KEY1', :value => '232')
+      SystemVariable.create(:name => 'KEY2', :value => '2322')
+      SystemVariable.create(:name => 'KEY3', :value => '2322')
+
+      setting = SystemVariable.find_by_name(:KEY1)
+      expect(setting.name).to eq('KEY1')
+      expect(setting.value).to eq('232')
+    end
+  end
+end


### PR DESCRIPTION
@mwangiann @ctumwebaze @andreweskeclarke 

This fix adds;
1. An interface for the administrator to define a score threshold below which solr results will be rejected.
2. Removes potential matches that the user has not interacted with (confirmed/marked as invalid) and recreates them
 when a solr match is done.
3. Changed the potential matches search to return a hash of the model identifiers with their scores.
4. Returning potential match objects instead of children from Enquiry#potential_matches, in order to show the score
5. Displays the score along with the child in the summary panel of the enquiry's matches.
