### PR TITLE
#185 Prompt admin to change password at first time login

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,6 +12,7 @@ class ApplicationController < ActionController::Base
   before_action :extend_session_lifetime
   before_action :set_locale
   around_action :set_current_user
+  before_action :force_password_change
 
   rescue_from(Exception, ActiveSupport::JSON.parse_error) do |e|
     fail e if Rails.env.development?
@@ -62,6 +63,12 @@ class ApplicationController < ActionController::Base
     response = yield if block_given?
     User.current_user = nil
     response
+  end
+
+  def force_password_change
+    if current_user && current_user.force_password_change?
+      redirect_to change_password_users_url
+    end
   end
 
   def clean_params(param)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,6 +3,7 @@ class UsersController < ApplicationController
   before_action :load_user, :only => [:show, :edit, :update, :destroy]
 
   skip_before_action :check_authentication, :set_locale, :only => :register_unverified
+  skip_before_action :force_password_change, :only => [:change_password, :update_password]
 
   def index
     authorize! :read, User

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -28,6 +28,7 @@ if should_seed? User
                'email' => 'rapidftr@rapidftr.com',
                'disabled' => 'false',
                'organisation' => 'N/A',
+               'force_password_change' => true,
                'role_ids' => [system_admin.id])
 
   User.create!('user_name' => 'field_worker',

--- a/spec/controllers/attachments_controller_spec.rb
+++ b/spec/controllers/attachments_controller_spec.rb
@@ -4,8 +4,6 @@ describe AttachmentsController, :type => :controller do
 
   before do
     fake_login
-    mock_user = double(:organisation => 'UNICEF')
-    allow(User).to receive(:find_by_user_name).with(anything).and_return(mock_user)
     allow(controller).to receive(:set_locale)
   end
 

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+describe HomeController, :type => :controller do
+  describe 'User#force_password_change?' do
+    it 'should redirect to change password page' do
+      user = User.new(:user_name => 'admin', :force_password_change => true)
+      fake_login_as_user(user)
+      get :index
+      expect(response).to redirect_to '/users/change_password'
+    end
+  end
+end

--- a/spec/controllers/user_preferences_controller_spec.rb
+++ b/spec/controllers/user_preferences_controller_spec.rb
@@ -11,7 +11,7 @@ describe UserPreferencesController, :type => :controller do
   end
 
   it 'should save the given local in user' do
-    mock_user = double('user', :user_name => 'UserName', :locale => 'en')
+    mock_user = double('user', :user_name => 'UserName', :locale => 'en', :force_password_change? => false)
     user_params = {'locale' => 'fr'}
     expect(User).to receive(:find_by_user_name).at_least(:once).and_return(mock_user)
     expect(mock_user).to receive(:update_attributes).with(user_params)
@@ -20,7 +20,7 @@ describe UserPreferencesController, :type => :controller do
   end
 
   it 'should flash a update message when the system language is changed' do
-    mock_user = double('user', :user_name => 'UserName', :locale => 'en')
+    mock_user = double('user', :user_name => 'UserName', :locale => 'en', :force_password_change? => false)
     user_params = {'locale' => 'zh'}
     expect(User).to receive(:find_by_user_name).at_least(:once).and_return(mock_user)
     expect(mock_user).to receive(:update_attributes).with(user_params).and_return(true)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -245,4 +245,32 @@ describe User, :type => :model do
       expect(ids).not_to include user2.id, user3.id, user4.id
     end
   end
+
+  describe 'force password change' do
+    it 'should default to false' do
+      expect(create(:user).force_password_change?).to be(false)
+    end
+
+    it 'should change to false after changed password' do
+      user = create :user, :user_name => 'hello', :verified => true, :force_password_change => true
+      expect(user.force_password_change?).to be(true)
+
+      user.reload
+
+      user.password = 'new_password'
+      user.password_confirmation = 'new_password'
+      user.save
+      expect(user.force_password_change?).to be(false)
+    end
+
+    it 'should not change to false if saved with same password' do
+      user = create :user, :verified => true, :force_password_change => true, :password => 'thepass'
+      user.reload
+
+      user.password = 'thepass'
+      user.password_confirmation = 'thepass'
+      user.save
+      expect(user.force_password_change?).to be(true)
+    end
+  end
 end


### PR DESCRIPTION
Added force password change option to user, setup rapidftr user with force_password_change => true

I may take an approach that is a little more complex than you expected, and I do feel it maybe too much changes for this issue. Please let me know your thoughts, and I'm happy to change to a much simpler change if you think current implementation is too complex for the case.
