### PR TITLE
hide matches tab on child view #266.

### DIFF
--- a/app/views/children/show.html.erb
+++ b/app/views/children/show.html.erb
@@ -85,7 +85,10 @@ $(".profile-tools .investigated a").click( function(){
     <div class="clearfix"></div>
     <%= render :partial => 'shared/sidebar', :locals => { :model => @child  } %>
     <%= render :partial => "shared/show_form_section", :locals => {:model => @child }%>
-    <%= render :partial => "potential_matches", :locals => {:model => @child} %>
+
+    <% if enquiries_enabled %>
+      <%= render :partial => "potential_matches", :locals => {:model => @child} %>
+    <% end %>
   </div>
 
 </div>

--- a/app/views/shared/_tabs_panel.html.erb
+++ b/app/views/shared/_tabs_panel.html.erb
@@ -1,10 +1,12 @@
 <div class="side-tab">
   <%= render :partial => "shared/tabs", :object => @form_sections %>
 
-  <ul class="tab-handles">
-    <li>
-      <a href="#tab_potential_matches"><%= t('enquiry.matches') %></a>
-    </li>
-  </ul>
+  <% if enquiries_enabled %>
+    <ul class="tab-handles">
+      <li>
+        <a href="#tab_potential_matches"><%= t('enquiry.matches') %></a>
+      </li>
+    </ul>
+  <% end %>
 
 </div>

--- a/spec/views/children/show.html.erb_spec.rb
+++ b/spec/views/children/show.html.erb_spec.rb
@@ -138,5 +138,22 @@ describe 'children/show.html.erb', :type => :view do
         expect(rendered).to have_link 'Export to CSV', link
       end
     end
+
+    context 'potential matches' do
+
+      it 'should not show matches tab when enquiries are turned off' do
+        enable_enquiries = SystemVariable.create!(:name => SystemVariable::ENABLE_ENQUIRIES, :type => 'boolean', :value => 0)
+        render
+        expect(rendered).not_to have_tag("a[href='#tab_potential_matches']")
+        enable_enquiries.destroy
+      end
+
+      it 'should show matches tab when enquries are turned on' do
+        enable_enquiries = SystemVariable.create!(:name => SystemVariable::ENABLE_ENQUIRIES, :type => 'boolean', :value => 1)
+        render
+        expect(rendered).to have_tag("a[href='#tab_potential_matches']")
+        enable_enquiries.destroy
+      end
+    end
   end
 end


### PR DESCRIPTION
when enquiries are turned off, the matches tab on the single child view
should not be shown.

this adds a check to ensure the matches tab and the potential matches
rendering is not show when the enquiries are turned off and shown when
they are turned on.