### PR TITLE
remove enquiries form #263

### DIFF
--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -2,6 +2,8 @@ class Form < CouchRest::Model::Base
   include RapidFTR::Model
   use_database :form
 
+  before_destroy :remove_form_sections
+
   property :name
 
   attr_accessor :sections
@@ -52,5 +54,14 @@ class Form < CouchRest::Model::Base
 
   def sorted_highlighted_fields
     highlighted_fields.sort { |field1, field2| field1.highlight_information.order.to_i <=> field2.highlight_information.order.to_i }
+  end
+
+  private
+
+  def remove_form_sections
+    form_sections = FormSection.all.all.select { |fs| fs.form == self }
+    unless form_sections.nil?
+      form_sections.each { |fs| fs.destroy }
+    end
   end
 end

--- a/lib/tasks/app.rake
+++ b/lib/tasks/app.rake
@@ -43,6 +43,12 @@ namespace :app do
       unless score_threshold.nil?
         score_threshold.destroy
       end
+
+      # remove enquiry form
+      form = Form.find_by_name(Enquiry::FORM_NAME)
+      unless form.nil?
+        form.destroy
+      end
     end
   end
 

--- a/spec/models/form_spec.rb
+++ b/spec/models/form_spec.rb
@@ -67,4 +67,32 @@ describe Form, :type => :model do
       @form.update_title_field 'title_field', false
     end
   end
+
+  describe 'removing a form' do
+    before :each do
+
+      FormSection.all.all.each { |fs| fs.destroy }
+      Form.all.all.each { |f| f.destroy }
+
+      @title_field = build :field, :name => 'title_field', :title_field => true, :highlighted => true
+      @f1 = build :field, :name => 'f1', :highlighted => true
+      @f2 = build :field, :name => 'f2', :highlighted => true
+
+      @form = build :form
+      @form.save!
+      @section1 = FormSection.create(:name => 'Section1', :fields => [@title_field], :form_id => @form.id)
+      @section2 = FormSection.create(:name => 'Section2', :fields => [@f1, @f2], :form_id => @form.id)
+    end
+
+    it 'should remove form sections for a form when the form is removed removed' do
+      sections = FormSection.all.all.select { |fs| fs.form == @form }
+      expect(sections.count).to eq(2)
+
+      @form.destroy
+      expect(FormSection.all.count).to eq(0)
+
+      sections = FormSection.all.all.select { |fs| fs.form == @form }
+      expect(sections.count).to eq(0)
+    end
+  end
 end


### PR DESCRIPTION
when enquiries are turned off, the system administrator should not be able to see the
enquiries form on the forms page.

this extends the rake task to remove the enquiries form from the system
when the enquiries are disabled.