### PR TITLE
create enable enquiries variable on disable

### DIFF
--- a/lib/tasks/app.rake
+++ b/lib/tasks/app.rake
@@ -33,7 +33,9 @@ namespace :app do
     desc 'Disable the enquiries feature'
     task :disable => :environment do
       enable_enquiries = SystemVariable.find_by_name(SystemVariable::ENABLE_ENQUIRIES)
-      unless enable_enquiries.nil?
+      if enable_enquiries.nil?
+        SystemVariable.create :name => SystemVariable::ENABLE_ENQUIRIES, :type => 'boolean', :value => '0'
+      else
         enable_enquiries.value = 0
         enable_enquiries.save!
       end


### PR DESCRIPTION
when the enable enquiries variable doesn't exist and one runs the
app:enquiries:disable task, it's not created. This leaves the app in an
inconsistent state with the enquiries for deleted but the value of the
variable cannot be determined there fore the system assumes enquiries
are still turned on.

this fix ensures the enquiries variable is created even when the disable
enquiries rake task is run.