### PR TITLE
remove mark as reunited/no reunited #259

### DIFF
--- a/app/views/children/_show_child_toolbar.erb
+++ b/app/views/children/_show_child_toolbar.erb
@@ -22,33 +22,35 @@
       <%= render :partial =>"suspect_flag", :locals => { :child => @child } %>
     </div>
 
-    <div class="btn dropdown_btn btn_reunite dropdown_form">
-      <% unless @child.reunited? %>
-          <%= render :partial => "mark_as",
-                     :locals=> {:child => @child,
-                                :mark_as_label => t("child.actions.reunited"),
-                                :mark_as_message_id => "reunited_message",
-                                :mark_as_message => t("child.actions.reunited_details"),
-                                :mark_as_property => "reunited",
-                                :mark_as_property_value => "true",
-                                :mark_as_submit_label => t("child.actions.reunite"),
-                                :error_message => t("child.messages.reunite_error_message"),
-                                :style => "flag"
-                     } %>
-      <% else %>
-          <%= render :partial => "mark_as",
-                     :locals=> { :child => @child,
-                                 :mark_as_label => t("child.actions.not_reunited"),
-                                 :mark_as_message_id => "reunited_message",
-                                 :mark_as_message => t("child.actions.undo_reunited_details"),
-                                 :mark_as_property => "reunited",
-                                 :mark_as_property_value => "false",
-                                 :mark_as_submit_label => t("child.actions.undo_reunite"),
-                                 :error_message => t("child.messages.undo_reunite_error_message"),
-                                 :style => "flag"
-                     } %>
-      <% end %>
-    </div>
+    <% if enquiries_enabled %>
+      <div class="btn dropdown_btn btn_reunite dropdown_form">
+        <% unless @child.reunited? %>
+            <%= render :partial => "mark_as",
+                       :locals=> {:child => @child,
+                                  :mark_as_label => t("child.actions.reunited"),
+                                  :mark_as_message_id => "reunited_message",
+                                  :mark_as_message => t("child.actions.reunited_details"),
+                                  :mark_as_property => "reunited",
+                                  :mark_as_property_value => "true",
+                                  :mark_as_submit_label => t("child.actions.reunite"),
+                                  :error_message => t("child.messages.reunite_error_message"),
+                                  :style => "flag"
+                       } %>
+        <% else %>
+            <%= render :partial => "mark_as",
+                       :locals=> { :child => @child,
+                                   :mark_as_label => t("child.actions.not_reunited"),
+                                   :mark_as_message_id => "reunited_message",
+                                   :mark_as_message => t("child.actions.undo_reunited_details"),
+                                   :mark_as_property => "reunited",
+                                   :mark_as_property_value => "false",
+                                   :mark_as_submit_label => t("child.actions.undo_reunite"),
+                                   :error_message => t("child.messages.undo_reunite_error_message"),
+                                   :style => "flag"
+                       } %>
+        <% end %>
+      </div>
+    <% end %>
 
     <div class="btn dropdown_btn btn_investigate dropdown_form">
       <% if @child.flag? %>

--- a/spec/views/children/show.html.erb_spec.rb
+++ b/spec/views/children/show.html.erb_spec.rb
@@ -139,20 +139,44 @@ describe 'children/show.html.erb', :type => :view do
       end
     end
 
-    context 'potential matches' do
-
-      it 'should not show matches tab when enquiries are turned off' do
-        enable_enquiries = SystemVariable.create!(:name => SystemVariable::ENABLE_ENQUIRIES, :type => 'boolean', :value => 0)
-        render
-        expect(rendered).not_to have_tag("a[href='#tab_potential_matches']")
-        enable_enquiries.destroy
+    context 'when enquiries are turned off' do
+      before :each do
+        @enable_enquiries = SystemVariable.create!(:name => SystemVariable::ENABLE_ENQUIRIES, :type => 'boolean', :value => 0)
       end
 
-      it 'should show matches tab when enquries are turned on' do
-        enable_enquiries = SystemVariable.create!(:name => SystemVariable::ENABLE_ENQUIRIES, :type => 'boolean', :value => 1)
+      after :each do
+        @enable_enquiries.destroy
+      end
+
+      it 'should not show matches tab when enquiries are turned off' do
+        render
+        expect(rendered).not_to have_tag("a[href='#tab_potential_matches']")
+      end
+
+      it 'should not show mark as reunited button' do
+        render
+        expect(rendered).not_to have_tag("div[class~='btn_reunite']")
+      end
+
+    end
+
+    context 'when enquiries are turned on' do
+      before :each do
+        @enable_enquiries = SystemVariable.create!(:name => SystemVariable::ENABLE_ENQUIRIES, :type => 'boolean', :value => 1)
+      end
+
+      after :each do
+        @enable_enquiries.destroy
+      end
+
+      it 'should show matches tab' do
         render
         expect(rendered).to have_tag("a[href='#tab_potential_matches']")
-        enable_enquiries.destroy
+      end
+
+      it 'should show mark as reunited button' do
+        render
+        expect(rendered).to have_tag("div[class~='btn_reunite']")
       end
     end
   end


### PR DESCRIPTION
when enquiries are disabled, the mark as reunited or mar as not reunited
buttons on the child view should not be shown.

this fix adds a conditional check to ensure the flag buttons are rendered only
when the enquiries feature is enabled.