### PR TITLE
making system variables uneditable [skip ci]

### DIFF
--- a/app/models/system_variable.rb
+++ b/app/models/system_variable.rb
@@ -4,6 +4,8 @@ class SystemVariable < CouchRest::Model::Base
   property :name, String
   property :value, String
   property :type, String, :default => 'string'
+  property :user_editable, TrueClass, :default => true
+
 
   validates :name, :presence => true, :uniqueness => true
   validates :value, :presence => true

--- a/app/views/system_variables/index.html.erb
+++ b/app/views/system_variables/index.html.erb
@@ -14,12 +14,16 @@
         <tr id="system-row-<%= variable.name %>">
           <td><%= variable.name %></td>
           <td>
-            <% if variable.type == 'number' %>
-              <%= text_field_tag "system_variables[#{variable.id}]", variable.value, :type => 'number', :step => '0.001', :min => '0'%>
-            <% elsif variable.type == 'boolean' %>
-              <%= select_tag("system_variables[#{variable.id}]", options_for_select([['Yes', '1'], ['No', '0']], variable.value))%>
+            <% if variable.user_editable %>
+              <% if variable.type == 'number' %>
+                <%= text_field_tag "system_variables[#{variable.id}]", variable.value, :type => 'number', :step => '0.001', :min => '0'%>
+              <% elsif variable.type == 'boolean' %>
+                <%= select_tag("system_variables[#{variable.id}]", options_for_select([['Yes', 'true'], ['No', 'false']], variable.value))%>
+              <% else %>
+                <%= text_field_tag "system_variables[#{variable.id}]", variable.value, :type => 'text' %>
+              <% end %>
             <% else %>
-              <%= text_field_tag "system_variables[#{variable.id}]", variable.value, :type => 'text' %>
+              <%= variable.value %>
             <% end %>
           </td>
           </td>

--- a/lib/tasks/app.rake
+++ b/lib/tasks/app.rake
@@ -17,9 +17,9 @@ namespace :app do
       # add the enable enquiries variable
       enable_enquiries = SystemVariable.find_by_name(SystemVariable::ENABLE_ENQUIRIES)
       if enable_enquiries.nil?
-        SystemVariable.create :name => SystemVariable::ENABLE_ENQUIRIES, :type => 'boolean', :value => true
+        SystemVariable.create :name => SystemVariable::ENABLE_ENQUIRIES, :type => 'boolean', :value => true, :user_editable => false
       else
-        enable_enquiries.value = 1
+        enable_enquiries.value = true
         enable_enquiries.save!
       end
 
@@ -40,9 +40,9 @@ namespace :app do
     task :disable => :environment do
       enable_enquiries = SystemVariable.find_by_name(SystemVariable::ENABLE_ENQUIRIES)
       if enable_enquiries.nil?
-        SystemVariable.create :name => SystemVariable::ENABLE_ENQUIRIES, :type => 'boolean', :value => '0'
+        SystemVariable.create :name => SystemVariable::ENABLE_ENQUIRIES, :type => 'boolean', :value => false, :user_editable => false
       else
-        enable_enquiries.value = 0
+        enable_enquiries.value = false
         enable_enquiries.save!
       end
 


### PR DESCRIPTION
some system variables should not be editable by the user by the user
should still be able to see the value of that variable.

to achieve that, an attribute user_editable was added to the system
variable model to store a value indicating whether the user can edit the
value of it or not and retrofitted the system variables view to account
for the value of that attribute.