### PR TITLE
sets user_editable flag on enquire disabling/enabling

### DIFF
--- a/lib/tasks/app.rake
+++ b/lib/tasks/app.rake
@@ -20,6 +20,7 @@ namespace :app do
         SystemVariable.create :name => SystemVariable::ENABLE_ENQUIRIES, :type => 'boolean', :value => true, :user_editable => false
       else
         enable_enquiries.value = true
+        enable_enquiries.user_editable = false
         enable_enquiries.save!
       end
 
@@ -43,6 +44,7 @@ namespace :app do
         SystemVariable.create :name => SystemVariable::ENABLE_ENQUIRIES, :type => 'boolean', :value => false, :user_editable => false
       else
         enable_enquiries.value = false
+        enable_enquiries.user_editable = false
         enable_enquiries.save!
       end
 


### PR DESCRIPTION
when the enable or disable tasks for the enquiries are run, the
user_editable property of the enable_enquiries system variable is also
set. This ensures that when the task is run against apps that already
have the enable_enquiries variable created will also have the right
state of the variable as expected by the app.