### PR TITLE
hide enquiries standard form sections rapidftr/tracker#255

### DIFF
--- a/app/models/forms/standard_forms_form.rb
+++ b/app/models/forms/standard_forms_form.rb
@@ -4,14 +4,19 @@ module Forms
     attr_accessor :forms
 
     def self.build_from_seed_data
+      form = new
+      form.forms = []
+
       child_form_sections = RapidFTR::ChildrenFormSectionSetup.build_form_sections
       child_form = StandardFormsData::FormData.build(Form.new(:name => Child::FORM_NAME), child_form_sections)
+      form.forms << child_form
 
-      form_sections = RapidFTR::EnquiriesFormSectionSetup.build_form_sections
-      enquiry_form = StandardFormsData::FormData.build(Form.new(:name => Enquiry::FORM_NAME), form_sections)
+      if Enquiry.enquiries_enabled?
+        form_sections = RapidFTR::EnquiriesFormSectionSetup.build_form_sections
+        enquiry_form = StandardFormsData::FormData.build(Form.new(:name => Enquiry::FORM_NAME), form_sections)
+        form.forms << enquiry_form
+      end
 
-      form = new
-      form.forms = [child_form, enquiry_form]
       form
     end
   end

--- a/lib/rapid_ftr/form_setup.rb
+++ b/lib/rapid_ftr/form_setup.rb
@@ -1,7 +1,9 @@
 module RapidFTR
   module FormSetup
     def self.default_forms
-      [default_form_for(Child::FORM_NAME), default_form_for(Enquiry::FORM_NAME)]
+      forms = [default_form_for(Child::FORM_NAME)]
+      forms << default_form_for(Enquiry::FORM_NAME) if Enquiry.enquiries_enabled?
+      forms
     end
 
     def self.default_form_for(form_name)

--- a/spec/models/forms/standard_forms_form_spec.rb
+++ b/spec/models/forms/standard_forms_form_spec.rb
@@ -103,4 +103,40 @@ describe Forms::StandardFormsForm do
       end
     end
   end
+
+  describe 'when enquiries are turned on or off' do
+    context ':off' do
+      before :each do
+        SystemVariable.all.each { |variable| variable.destroy }
+        @enable_enquiries = SystemVariable.create(:name => SystemVariable::ENABLE_ENQUIRIES, :type => 'boolean', :value => '0')
+      end
+
+      after :each do
+        @enable_enquiries.destroy
+      end
+
+      it 'should not build formsections for enquiries' do
+        forms = Forms::StandardFormsForm.build_from_seed_data.forms
+        expect(forms.count).to eq 1
+        expect(forms.map { |form| form.name }).to_not include Enquiry::FORM_NAME
+      end
+    end
+
+    context ':on' do
+      before :each do
+        SystemVariable.all.each { |variable| variable.destroy }
+        @enable_enquiries = SystemVariable.create(:name => SystemVariable::ENABLE_ENQUIRIES, :type => 'boolean', :value => '1')
+      end
+
+      after :each do
+        @enable_enquiries.destroy
+      end
+
+      it 'should build formsections for enquiries' do
+        forms = Forms::StandardFormsForm.build_from_seed_data.forms
+        expect(forms.count).to eq 2
+        expect(forms.map { |form| form.name }).to include Enquiry::FORM_NAME
+      end
+    end
+  end
 end


### PR DESCRIPTION
when enquiries are disabled, the administrator should not be able to add
enquiries standard form sections through the forms interface.

to achieve this, the build standard forms routine in the
standard_forms_form first checks whether enquiries are enabled to include
the form and form_sections for enquiries.