### PR TITLE
Small fix to allow installing new plugins in the same directory

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,7 +6,7 @@ VAGRANTFILE_API_VERSION = '2'
 
 # Check required plugins
 REQUIRED_PLUGINS = %w(vagrant-omnibus vagrant-faster)
-exit unless ARGV[0] == 'plugin' and REQUIRED_PLUGINS.all? do |plugin|
+exit unless ARGV[0] == 'plugin' or REQUIRED_PLUGINS.all? do |plugin|
   Vagrant.has_plugin?(plugin) || (
     puts "The #{plugin} plugin is required. Please install it with:"
     puts "$ vagrant plugin install #{plugin}"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,7 +6,7 @@ VAGRANTFILE_API_VERSION = '2'
 
 # Check required plugins
 REQUIRED_PLUGINS = %w(vagrant-omnibus vagrant-faster)
-exit unless REQUIRED_PLUGINS.all? do |plugin|
+exit unless ARGV[0] == 'plugin' and REQUIRED_PLUGINS.all? do |plugin|
   Vagrant.has_plugin?(plugin) || (
     puts "The #{plugin} plugin is required. Please install it with:"
     puts "$ vagrant plugin install #{plugin}"


### PR DESCRIPTION
vagrant will parse the Vagrantfile when trying to install the plugin and exit.

You should probably squash this.